### PR TITLE
Seed Contentful with sample pages, blogs, and pageBuilder blocks

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,8 @@
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
-    "test:e2e:ui": "playwright test --ui"
+    "test:e2e:ui": "playwright test --ui",
+    "seed": "node --env-file=.env scripts/seed-contentful.mjs"
   },
   "dependencies": {
     "@contentful/live-preview": "^4.10.5",
@@ -64,6 +65,7 @@
     "@vitest/coverage-v8": "^3.2.2",
     "@workspace/eslint-config": "workspace:^",
     "@workspace/typescript-config": "workspace:*",
+    "contentful-management": "^11.59.4",
     "jsdom": "^26.1.0",
     "postcss": "^8",
     "tailwindcss": "^4.1",

--- a/apps/web/scripts/seed-contentful.mjs
+++ b/apps/web/scripts/seed-contentful.mjs
@@ -1,0 +1,707 @@
+// Idempotent Contentful seed: blogs, pages, pageBuilder blocks, authors, assets.
+// Re-running skips existing entries (deterministic IDs). Run: pnpm --filter web seed
+//
+// Requires env: CONTENTFUL_SPACE_ID, CONTENTFUL_ENVIRONMENT, CONTENTFUL_MANAGEMENT_TOKEN
+
+import contentful from "contentful-management";
+
+const { SPACE_ID, ENV_ID, TOKEN } = readEnv();
+const PUBLISH = process.env.SEED_PUBLISH !== "false";
+
+const client = contentful.createClient({ accessToken: TOKEN });
+const space = await client.getSpace(SPACE_ID);
+const env = await space.getEnvironment(ENV_ID);
+
+const locales = await env.getLocales();
+const LOCALE = locales.items.find((l) => l.default)?.code ?? "en-US";
+log(`✓ space=${SPACE_ID} env=${ENV_ID} locale=${LOCALE} publish=${PUBLISH}`);
+
+// ---------------------------------------------------------------- assets ----
+
+const ASSETS = {
+  "seed-hero-home": {
+    title: "Glowing data center",
+    url: "https://images.unsplash.com/photo-1558494949-ef010cbdcc31?w=2400&q=80",
+  },
+  "seed-hero-about": {
+    title: "Team collaborating around laptop",
+    url: "https://images.unsplash.com/photo-1522071820081-009f0129c71c?w=2400&q=80",
+  },
+  "seed-hero-pricing": {
+    title: "Charts on a glass wall",
+    url: "https://images.unsplash.com/photo-1551288049-bebda4e38f71?w=2400&q=80",
+  },
+  "seed-hero-features": {
+    title: "Server racks blue light",
+    url: "https://images.unsplash.com/photo-1591488320449-011701bb6704?w=2400&q=80",
+  },
+  "seed-hero-contact": {
+    title: "Conversation over coffee",
+    url: "https://images.unsplash.com/photo-1521737711867-e3b97375f902?w=2400&q=80",
+  },
+  "seed-blog-1": {
+    title: "Abstract code on dark background",
+    url: "https://images.unsplash.com/photo-1555066931-4365d14bab8c?w=1600&q=80",
+  },
+  "seed-blog-2": {
+    title: "Modern workspace setup",
+    url: "https://images.unsplash.com/photo-1498050108023-c5249f4df085?w=1600&q=80",
+  },
+  "seed-blog-3": {
+    title: "Designer color palette",
+    url: "https://images.unsplash.com/photo-1517694712202-14dd9538aa97?w=1600&q=80",
+  },
+  "seed-blog-4": {
+    title: "Network cables backlit",
+    url: "https://images.unsplash.com/photo-1544197150-b99a580bb7a8?w=1600&q=80",
+  },
+  "seed-blog-5": {
+    title: "Whiteboard sprint planning",
+    url: "https://images.unsplash.com/photo-1542744173-8e7e53415bb0?w=1600&q=80",
+  },
+  "seed-blog-6": {
+    title: "Migration arrows on whiteboard",
+    url: "https://images.unsplash.com/photo-1521791136064-7986c2920216?w=1600&q=80",
+  },
+  "seed-author-jane": {
+    title: "Jane portrait",
+    url: "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=600&q=80",
+  },
+  "seed-author-marcus": {
+    title: "Marcus portrait",
+    url: "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=600&q=80",
+  },
+  "seed-author-priya": {
+    title: "Priya portrait",
+    url: "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=600&q=80",
+  },
+};
+
+for (const [id, spec] of Object.entries(ASSETS)) {
+  await upsertAsset(id, spec);
+}
+
+// ---------------------------------------------------------------- authors ---
+
+const AUTHORS = {
+  "seed-author-jane": {
+    name: "Jane Okafor",
+    position: "Principal Engineer",
+    bio: "Jane leads platform engineering and writes about caching, edge runtimes, and developer experience.",
+  },
+  "seed-author-marcus": {
+    name: "Marcus Lindgren",
+    position: "Staff Frontend Engineer",
+    bio: "Marcus ships React all day. Currently obsessed with React Compiler and zero-runtime CSS.",
+  },
+  "seed-author-priya": {
+    name: "Priya Raman",
+    position: "Head of Content Engineering",
+    bio: "Priya bridges editors and engineers. Previously led content platforms at two unicorn startups.",
+  },
+};
+
+for (const [id, spec] of Object.entries(AUTHORS)) {
+  await upsertEntry(id, "author", {
+    name: spec.name,
+    position: spec.position,
+    bio: spec.bio,
+    image: link(id, "Asset"), // author id == matching asset id by convention
+  });
+}
+
+// ----------------------------------------------------------- buttons (reusable)
+
+await upsertEntry("seed-btn-primary-cta", "button", {
+  variant: "default",
+  label: "Get started",
+  href: "/contact",
+});
+await upsertEntry("seed-btn-secondary-docs", "button", {
+  variant: "outline",
+  label: "Read the docs",
+  href: "https://www.contentful.com/developers/docs/",
+});
+await upsertEntry("seed-btn-pricing-link", "button", {
+  variant: "link",
+  label: "See pricing →",
+  href: "/pricing",
+});
+
+// ----------------------------------------------------------- pagebuilder blocks
+
+// Heroes — one per page/blog so editors can iterate independently
+await upsertEntry("seed-hero-home-block", "hero", {
+  title: "Build content-driven sites without the rebuild treadmill",
+  badge: "v2.0 ships today",
+  richText: rt([
+    "A composable content platform with Contentful, Next.js 16, and Tailwind v4. Designed for teams that want preview-grade DX without sacrificing production performance.",
+  ]),
+  image: link("seed-hero-home", "Asset"),
+  buttons: [link("seed-btn-primary-cta"), link("seed-btn-secondary-docs")],
+});
+
+await upsertEntry("seed-hero-about-block", "hero", {
+  title: "We're a small team obsessed with editor velocity",
+  badge: "About us",
+  richText: rt([
+    "Founded in 2024 by content engineers tired of stale staging environments. We build tools that let writers and developers ship in the same hour.",
+  ]),
+  image: link("seed-hero-about", "Asset"),
+  buttons: [link("seed-btn-pricing-link")],
+});
+
+await upsertEntry("seed-hero-pricing-block", "hero", {
+  title: "Pricing that scales with your content team",
+  badge: "Transparent pricing",
+  richText: rt([
+    "Start free for small projects. Pay only for active editors. No per-entry pricing, no surprise overage fees.",
+  ]),
+  image: link("seed-hero-pricing", "Asset"),
+  buttons: [link("seed-btn-primary-cta")],
+});
+
+await upsertEntry("seed-hero-features-block", "hero", {
+  title: "Everything you need, nothing you don't",
+  badge: "Features",
+  richText: rt([
+    "Live preview, partial revalidation, type-safe content models, and a page builder that respects your design system.",
+  ]),
+  image: link("seed-hero-features", "Asset"),
+  buttons: [link("seed-btn-secondary-docs"), link("seed-btn-pricing-link")],
+});
+
+await upsertEntry("seed-hero-contact-block", "hero", {
+  title: "Get in touch",
+  badge: "Contact",
+  richText: rt([
+    "Drop a note and we'll get back within one business day. For urgent support, paid plans include a dedicated Slack channel.",
+  ]),
+  image: link("seed-hero-contact", "Asset"),
+  buttons: [link("seed-btn-primary-cta")],
+});
+
+await upsertEntry("seed-hero-careers-block", "hero", {
+  title: "Build the future of content with us",
+  badge: "We're hiring",
+  richText: rt([
+    "Remote-first across the EU and Americas. Async-by-default. Engineers, designers, and content folks welcome — see open roles below.",
+  ]),
+  image: link("seed-hero-about", "Asset"),
+  buttons: [link("seed-btn-primary-cta"), link("seed-btn-secondary-docs")],
+});
+
+// Feature cards (children)
+const featureCardDefs = [
+  {
+    id: "seed-fc-livepreview",
+    title: "Live Preview without reloads",
+    color: "blue",
+    body: "See editor changes in the browser within ~100ms via Contentful's Live Preview SDK and React 19 server components.",
+    icon: "seed-blog-1",
+  },
+  {
+    id: "seed-fc-typed",
+    title: "Type-safe content models",
+    color: "pink",
+    body: "Generated TypeScript types from your Contentful space — never ship a field rename that breaks production.",
+    icon: "seed-blog-2",
+  },
+  {
+    id: "seed-fc-revalidation",
+    title: "Surgical revalidation",
+    color: "yellow",
+    body: "Tag-based cache invalidation via the /api/revalidate webhook means only changed entries refetch. The rest stays cached.",
+    icon: "seed-blog-3",
+  },
+  {
+    id: "seed-fc-pagebuilder",
+    title: "Composable page builder",
+    color: "red",
+    body: "Hero, FAQ, CTA, and feature card blocks editors can rearrange. New block types take ~20 lines of code to add.",
+    icon: "seed-blog-4",
+  },
+  {
+    id: "seed-fc-starter",
+    title: "Starter Plan",
+    color: "blue",
+    body: "Free forever for personal projects. 1 editor, 1 environment, community support.",
+  },
+  {
+    id: "seed-fc-team",
+    title: "Team Plan",
+    color: "pink",
+    body: "Everything in Starter plus unlimited editors, 3 environments, priority email support, and SSO.",
+  },
+  {
+    id: "seed-fc-enterprise",
+    title: "Enterprise Plan",
+    color: "yellow",
+    body: "Custom SLAs, dedicated infrastructure, advanced compliance, and a named customer success engineer.",
+  },
+];
+
+for (const card of featureCardDefs) {
+  await upsertEntry(card.id, "featureCard", {
+    title: card.title,
+    cardGradientColor: card.color,
+    richText: rt([card.body]),
+    ...(card.icon ? { icon: link(card.icon, "Asset") } : {}),
+  });
+}
+
+await upsertEntry("seed-featurecards-home", "featureCards", {
+  eyebrow: "WHAT YOU SHIP",
+  title: "Four primitives that compose into anything",
+  richText: rt([
+    "Each block is a Contentful content type and a React component. Editors drag and drop, developers stay in their lane.",
+  ]),
+  cards: [
+    link("seed-fc-livepreview"),
+    link("seed-fc-typed"),
+    link("seed-fc-revalidation"),
+    link("seed-fc-pagebuilder"),
+  ],
+});
+
+await upsertEntry("seed-featurecards-pricing", "featureCards", {
+  eyebrow: "PLANS",
+  title: "Pick a plan, change it any time",
+  richText: rt([
+    "Annual billing saves 15%. Every plan includes Live Preview and unlimited content types.",
+  ]),
+  cards: [
+    link("seed-fc-starter"),
+    link("seed-fc-team"),
+    link("seed-fc-enterprise"),
+  ],
+});
+
+await upsertEntry("seed-featurecards-features", "featureCards", {
+  eyebrow: "CAPABILITIES",
+  title: "Designed for content teams that ship daily",
+  cards: [
+    link("seed-fc-livepreview"),
+    link("seed-fc-revalidation"),
+    link("seed-fc-pagebuilder"),
+  ],
+});
+
+// FAQ children
+const faqDefs = [
+  {
+    id: "seed-faq-hosting",
+    q: "Where is my content hosted?",
+    a: "Contentful CDN globally. The Next.js app runs on Vercel by default but works on any Node 20+ host.",
+  },
+  {
+    id: "seed-faq-migration",
+    q: "Can I migrate from an existing CMS?",
+    a: "Yes. We provide a content migration runbook and contentful-cli scripts for common platforms (Sanity, Strapi, WordPress).",
+  },
+  {
+    id: "seed-faq-preview",
+    q: "How does Live Preview work?",
+    a: "The /api/preview route enables Next.js draft mode and the Contentful Live Preview SDK streams field-level updates over postMessage.",
+  },
+  {
+    id: "seed-faq-cache",
+    q: "How is caching handled?",
+    a: "Next.js fetch cache + Contentful webhook → /api/revalidate → revalidateTag for surgical invalidation.",
+  },
+  {
+    id: "seed-faq-pricing",
+    q: "Do you charge per page view?",
+    a: "No. Pricing is per editor seat. Page views are unmetered.",
+  },
+  {
+    id: "seed-faq-support",
+    q: "What does support look like?",
+    a: "Community Discord for free, email for Team, dedicated Slack channel for Enterprise.",
+  },
+];
+
+for (const f of faqDefs) {
+  await upsertEntry(f.id, "faq", {
+    question: f.q,
+    answer: rt([f.a]),
+  });
+}
+
+await upsertEntry("seed-faqs-home", "faqAccordion", {
+  eyebrow: "FAQ",
+  title: "Frequently asked questions",
+  subtitle: "Can't find what you're looking for? Drop us a note.",
+  faqs: [
+    link("seed-faq-hosting"),
+    link("seed-faq-preview"),
+    link("seed-faq-cache"),
+    link("seed-faq-migration"),
+  ],
+  link: "/contact",
+});
+
+await upsertEntry("seed-faqs-features", "faqAccordion", {
+  eyebrow: "QUESTIONS",
+  title: "Common questions about features",
+  faqs: [link("seed-faq-preview"), link("seed-faq-cache"), link("seed-faq-support")],
+});
+
+// CTAs
+await upsertEntry("seed-cta-home", "callToAction", {
+  eyebrow: "GET STARTED",
+  title: "Ready to ship?",
+  richText: rt([
+    "Start free, no credit card required. Get a feel for Live Preview in under five minutes.",
+  ]),
+  buttons: [link("seed-btn-primary-cta"), link("seed-btn-secondary-docs")],
+});
+
+await upsertEntry("seed-cta-about", "callToAction", {
+  eyebrow: "JOIN US",
+  title: "We're hiring",
+  richText: rt(["We're a remote-first team. See open roles or send a note."]),
+  buttons: [link("seed-btn-primary-cta")],
+});
+
+await upsertEntry("seed-cta-pricing", "callToAction", {
+  eyebrow: "STILL DECIDING?",
+  title: "Talk to sales",
+  richText: rt(["Book a 20-minute call to see if we're a fit for your team."]),
+  buttons: [link("seed-btn-primary-cta")],
+});
+
+await upsertEntry("seed-cta-contact", "callToAction", {
+  eyebrow: "NEWSLETTER",
+  title: "Stay in the loop",
+  richText: rt(["Monthly product updates and engineering essays. No spam."]),
+  enableNewsletterForm: true,
+  helperText: rt(["We'll never share your email. Unsubscribe any time."]),
+});
+
+await upsertEntry("seed-cta-blog", "callToAction", {
+  eyebrow: "READ MORE",
+  title: "Get articles like this in your inbox",
+  richText: rt([
+    "Engineering essays on content platforms, React, and the modern web. One email a month.",
+  ]),
+  enableNewsletterForm: true,
+});
+
+// -------------------------------------------------------------- pages -------
+
+// Note: existing space already has a "/" home page. We expose our home composition
+// at "/home-demo" so editors can see all 4 block types without clobbering the live home.
+await upsertEntry("seed-page-home", "page", {
+  title: "Home Demo",
+  description: "Demo composition showing all four pageBuilder blocks.",
+  slug: "/home-demo",
+  image: link("seed-hero-home", "Asset"),
+  pageBuilder: [
+    link("seed-hero-home-block"),
+    link("seed-featurecards-home"),
+    link("seed-faqs-home"),
+    link("seed-cta-home"),
+  ],
+  seoTitle: "Home Demo — Roboto",
+  seoDescription:
+    "Contentful + Next.js 16 + Tailwind v4. Live Preview, type-safe content models, surgical revalidation.",
+});
+
+await upsertEntry("seed-page-about", "page", {
+  title: "About",
+  description: "Meet the team behind Roboto.",
+  slug: "/about",
+  image: link("seed-hero-about", "Asset"),
+  pageBuilder: [link("seed-hero-about-block"), link("seed-cta-about")],
+  seoTitle: "About — Roboto",
+  seoDescription: "We're a small team obsessed with editor velocity and developer experience.",
+});
+
+await upsertEntry("seed-page-pricing", "page", {
+  title: "Pricing",
+  description: "Per-editor pricing. No per-pageview fees.",
+  slug: "/pricing",
+  image: link("seed-hero-pricing", "Asset"),
+  pageBuilder: [
+    link("seed-hero-pricing-block"),
+    link("seed-featurecards-pricing"),
+    link("seed-cta-pricing"),
+  ],
+  seoTitle: "Pricing — Roboto",
+  seoDescription: "Per-editor pricing with no per-pageview fees. Plans for solo, team, and enterprise.",
+});
+
+await upsertEntry("seed-page-features", "page", {
+  title: "Features",
+  description: "Live Preview, type-safe content, and surgical revalidation.",
+  slug: "/features",
+  image: link("seed-hero-features", "Asset"),
+  pageBuilder: [
+    link("seed-hero-features-block"),
+    link("seed-featurecards-features"),
+    link("seed-faqs-features"),
+  ],
+  seoTitle: "Features — Roboto",
+  seoDescription:
+    "Live Preview, type-safe content models, surgical revalidation, composable page builder.",
+});
+
+await upsertEntry("seed-page-contact", "page", {
+  title: "Contact",
+  description: "Get in touch with the team.",
+  slug: "/contact",
+  image: link("seed-hero-contact", "Asset"),
+  pageBuilder: [link("seed-hero-contact-block"), link("seed-cta-contact")],
+  seoTitle: "Contact — Roboto",
+  seoDescription: "Get in touch. Sales, support, partnerships — we read everything.",
+});
+
+await upsertEntry("seed-page-careers", "page", {
+  title: "Careers",
+  description: "We're hiring engineers, designers, and content folks.",
+  slug: "/careers",
+  image: link("seed-hero-about", "Asset"),
+  pageBuilder: [link("seed-hero-careers-block"), link("seed-cta-about")],
+  seoTitle: "Careers — Roboto",
+  seoDescription:
+    "Open roles at Roboto. Remote-first, async-by-default, generous equity.",
+});
+
+// -------------------------------------------------------------- blogs -------
+
+const blogDefs = [
+  {
+    id: "seed-blog-1",
+    title: "Why we rebuilt our content layer on Contentful",
+    description: "A six-week migration from a legacy CMS, and what we'd do differently next time.",
+    slug: "why-we-rebuilt-on-contentful",
+    publishedDate: "2026-04-12",
+    author: "seed-author-jane",
+    paragraphs: [
+      "When we started Roboto in late 2024, we inherited a legacy WordPress install that had grown into a content monolith. Editors loved the WYSIWYG, but every release required a cache stampede and a prayer.",
+      "Contentful's content-as-data model gave us strict schemas, an API that's a joy to consume, and a Live Preview SDK that finally closed the editor feedback loop. Six weeks later we'd migrated every entry and retired the old stack.",
+      "The biggest unlock wasn't speed — it was confidence. Editors can now ship copy at 5pm on a Friday without paging the on-call.",
+    ],
+  },
+  {
+    id: "seed-blog-2",
+    title: "Live Preview without the loading spinners",
+    description: "How we wired Contentful Live Preview into Next.js 16 server components.",
+    slug: "live-preview-without-spinners",
+    publishedDate: "2026-04-22",
+    author: "seed-author-marcus",
+    paragraphs: [
+      "Next.js 16 server components plus Contentful's Live Preview SDK is a great combination — once you stop fighting it. The trick is to keep the editor in a single React tree and let postMessage updates drive re-renders.",
+      "We use useContentfulLiveUpdates at the section level and useContentfulInspectorMode for tap-to-edit affordances. Field-level updates feel instantaneous.",
+      "The reference implementation lives in apps/web/src/components/sections/hero.tsx. Copy it for new blocks.",
+    ],
+  },
+  {
+    id: "seed-blog-3",
+    title: "Tailwind v4 in production: three months in",
+    description: "What we love, what bit us, and the CSS-first migration we'd recommend.",
+    slug: "tailwind-v4-three-months-in",
+    publishedDate: "2026-05-01",
+    author: "seed-author-marcus",
+    paragraphs: [
+      "Tailwind v4 removed the JS config and moved theme tokens into CSS via @theme. The migration took us a weekend and reduced our build pipeline complexity meaningfully.",
+      "The wins: faster builds, simpler tooling, and design tokens live next to component CSS instead of in a separate config file. The pain: any custom plugin had to be rewritten as a CSS @plugin import.",
+      "Three months in, we wouldn't go back. Even our designers like it — they can read globals.css.",
+    ],
+  },
+  {
+    id: "seed-blog-4",
+    title: "Cache invalidation done right: revalidateTag patterns",
+    description: "Surgical Next.js cache invalidation driven by Contentful webhooks.",
+    slug: "revalidate-tag-patterns",
+    publishedDate: "2026-05-08",
+    author: "seed-author-jane",
+    paragraphs: [
+      "Phil Karlton was right: cache invalidation is hard. But it's a lot easier when your CMS tells you exactly what changed.",
+      "Our /api/revalidate route accepts a tag or path from Contentful's webhook, validates the signing secret, and calls revalidateTag. The fetch layer tags every Contentful response with the entry ID, so updates propagate within seconds.",
+      "The end result: editors publish, and the change appears on the live site without a redeploy or a manual cache flush.",
+    ],
+  },
+  {
+    id: "seed-blog-5",
+    title: "Type-safe content models with cf-content-types-generator",
+    description: "How we keep TypeScript and Contentful in lockstep with one CLI command.",
+    slug: "type-safe-content-models",
+    publishedDate: "2026-05-13",
+    author: "seed-author-priya",
+    paragraphs: [
+      "Generated types make field renames safe. Run pnpm typegen, get a compile error in the offending consumer, fix it before merging. That's the loop.",
+      "We use cf-content-types-generator with --v10 to match the Contentful SDK's WITHOUT_UNRESOLVABLE_LINKS modifier. Types land in apps/web/src/lib/contentful/types and get linted on commit.",
+      "If you're building anything bigger than a marketing site, you want this in your pipeline.",
+    ],
+  },
+  {
+    id: "seed-blog-6",
+    title: "Migrating from headless legacy: a 6-week playbook",
+    description: "Phase-by-phase migration plan for teams moving off Sanity, Strapi, or Prismic.",
+    slug: "migrating-from-headless-legacy",
+    publishedDate: "2026-05-18",
+    author: "seed-author-priya",
+    paragraphs: [
+      "Most CMS migrations fail not because the destination is bad — they fail because the timeline is unrealistic. Six weeks is a sweet spot for teams under 20 editors.",
+      "Week 1: schema design. Week 2: content migration script. Weeks 3–4: parallel write to both systems. Week 5: cutover. Week 6: legacy retirement and editor training.",
+      "The single biggest source of risk is reference fields. Map them carefully — Contentful's link types are stricter than most legacy systems.",
+    ],
+  },
+];
+
+for (const b of blogDefs) {
+  await upsertEntry(b.id + "-entry", "blog", {
+    title: b.title,
+    description: b.description,
+    slug: b.slug,
+    publishedDate: b.publishedDate,
+    image: link(b.id, "Asset"),
+    authors: [link(b.author)],
+    richText: rt(b.paragraphs),
+    pageBuilder: [link("seed-cta-blog")],
+    seoTitle: b.title,
+    seoDescription: b.description,
+  });
+}
+
+log(`\n✓ done`);
+process.exit(0);
+
+// ============================================================== helpers ====
+
+function readEnv() {
+  const SPACE_ID = process.env.CONTENTFUL_SPACE_ID;
+  const ENV_ID = process.env.CONTENTFUL_ENVIRONMENT || "master";
+  const TOKEN = process.env.CONTENTFUL_MANAGEMENT_TOKEN;
+  if (!SPACE_ID || !TOKEN) {
+    console.error(
+      "Missing CONTENTFUL_SPACE_ID or CONTENTFUL_MANAGEMENT_TOKEN. Populate apps/web/.env first.",
+    );
+    process.exit(1);
+  }
+  return { SPACE_ID, ENV_ID, TOKEN };
+}
+
+function localized(value) {
+  return { [LOCALE]: value };
+}
+
+function link(id, linkType = "Entry") {
+  return { sys: { type: "Link", linkType, id } };
+}
+
+function rt(paragraphs) {
+  return {
+    nodeType: "document",
+    data: {},
+    content: paragraphs.map((text) => ({
+      nodeType: "paragraph",
+      data: {},
+      content: [{ nodeType: "text", value: text, marks: [], data: {} }],
+    })),
+  };
+}
+
+function log(msg) {
+  console.log(msg);
+}
+
+async function upsertAsset(id, { title, url }) {
+  const existing = await tryGet(() => env.getAsset(id));
+  if (existing) {
+    const hasFile = !!existing.fields.file?.[LOCALE]?.url;
+    if (!hasFile) {
+      log(`  asset ${id} broken — recreating`);
+      if (existing.isPublished()) await existing.unpublish();
+      const fresh = await env.getAsset(id);
+      await fresh.delete();
+    } else {
+      if (PUBLISH && !existing.isPublished()) {
+        const fresh = await env.getAsset(id);
+        await fresh.publish();
+        log(`  asset ${id} published`);
+      } else {
+        log(`  asset ${id} exists`);
+      }
+      return;
+    }
+  }
+  const fileName = `${id}.jpg`;
+  const created = await env.createAssetWithId(id, {
+    fields: {
+      title: localized(title),
+      description: localized(title),
+      file: localized({ contentType: "image/jpeg", fileName, upload: url }),
+    },
+  });
+  try {
+    await created.processForAllLocales({
+      processingCheckWait: 2000,
+      processingCheckRetries: 30,
+    });
+  } catch {
+    // fall through — we poll below regardless
+  }
+  for (let i = 0; i < 30; i++) {
+    const a = await env.getAsset(id);
+    if (a.fields.file?.[LOCALE]?.url) {
+      if (PUBLISH) await a.publish();
+      log(`  asset ${id} created${PUBLISH ? " + published" : ""}`);
+      return;
+    }
+    await sleep(2000);
+  }
+  throw new Error(`Asset ${id} processing timeout`);
+}
+
+async function upsertEntry(id, contentType, fields) {
+  const localizedFields = Object.fromEntries(
+    Object.entries(fields).map(([k, v]) => [k, localized(v)]),
+  );
+  const existing = await tryGet(() => env.getEntry(id));
+  if (existing) {
+    const drift = fieldsDrift(existing.fields, localizedFields);
+    if (drift) {
+      Object.assign(existing.fields, localizedFields);
+      const updated = await existing.update();
+      if (PUBLISH) await updated.publish();
+      log(`  entry ${id} (${contentType}) updated${PUBLISH ? " + published" : ""}`);
+      return;
+    }
+    if (PUBLISH && !existing.isPublished()) {
+      const fresh = await env.getEntry(id);
+      await fresh.publish();
+      log(`  entry ${id} (${contentType}) published`);
+    } else {
+      log(`  entry ${id} (${contentType}) exists`);
+    }
+    return;
+  }
+  const entry = await env.createEntryWithId(contentType, id, { fields: localizedFields });
+  if (PUBLISH) await entry.publish();
+  log(`  entry ${id} (${contentType}) created${PUBLISH ? " + published" : ""}`);
+}
+
+function fieldsDrift(current, desired) {
+  for (const [k, v] of Object.entries(desired)) {
+    if (JSON.stringify(current?.[k]) !== JSON.stringify(v)) return true;
+  }
+  return false;
+}
+
+async function tryGet(fn) {
+  try {
+    return await fn();
+  } catch (err) {
+    if (err?.name === "NotFound" || err?.status === 404 || /NotFound/.test(String(err))) {
+      return null;
+    }
+    throw err;
+  }
+}
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}

--- a/apps/web/src/lib/contentful-utils.ts
+++ b/apps/web/src/lib/contentful-utils.ts
@@ -18,11 +18,12 @@ export function getButtonUrl(
 
   // Internal page reference for page links
   if (button.fields.internal?.fields?.slug) {
+    const cleanSlug = button.fields.internal.fields.slug.replace(/^\//, "");
     if (button.fields.internal.sys.contentType.sys.id === "page") {
-      return `/${button.fields.internal.fields.slug}`;
+      return `/${cleanSlug}`;
     }
     if (button.fields.internal.sys.contentType.sys.id === "blog") {
-      return `/blog/${button.fields.internal.fields.slug}`;
+      return `/blog/${cleanSlug}`;
     }
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       babel-plugin-react-compiler:
         specifier: 19.0.0-beta-e993439-20250328
         version: 19.0.0-beta-e993439-20250328
+      contentful-management:
+        specifier: ^11.59.4
+        version: 11.76.0
       eslint:
         specifier: ^10.4.0
         version: 10.4.0(jiti@2.7.0)
@@ -1768,12 +1771,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.40.2':
-    resolution: {integrity: sha512-lG7Xa+BmBNwpjmVUbmyKxdQJ3Q6whHjMjzQplOs5Z+Gj7mxPtWakGHqzMqNER68G67kmCX9qX57aRsW5V0VOng==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-x64-gnu@4.60.4':
     resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
     cpu: [x64]
@@ -2280,9 +2277,6 @@ packages:
   axios@1.16.1:
     resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
 
-  axios@1.9.0:
-    resolution: {integrity: sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==}
-
   babel-plugin-react-compiler@19.0.0-beta-e993439-20250328:
     resolution: {integrity: sha512-eq0lxXDicCNfhtIhm2L2nW2FyDcPMfuJTQG641ZWMWxEVqwmtUlAkWXC4o5C3vykhWMTsXmiJe7/hxXVUbV8ZA==}
 
@@ -2456,6 +2450,10 @@ packages:
     resolution: {integrity: sha512-d/7ydc4HOVKNqT789T9hL0fu4i1U1AthjQV+PfJevwZo4JyzNvh2I5wpaJUqV859bJHSNsTfV6gdtLHg9bx0bA==}
     engines: {node: '>=18'}
 
+  contentful-management@11.76.0:
+    resolution: {integrity: sha512-KsqIZ65q1A6IP55sxTfuAMhBTNJfgGxlVZBoV2ghBuR1LaZZyTqway5vj9KHRDl/Z1uOQQsYSiz+FayMxBXXEw==}
+    engines: {node: '>=18'}
+
   contentful-management@12.5.0:
     resolution: {integrity: sha512-RXVuwmBIKlu6gziA06X8kLnQpP4d2PlWSc/4T1ezio2ErE0oKXN6kCagFSme/QUR5HuqAksp1jL8aJ+EFx7gqQ==}
     engines: {node: '>=20'}
@@ -2467,10 +2465,6 @@ packages:
   contentful-resolve-response@1.9.8:
     resolution: {integrity: sha512-gudcrg8Z2pt+Gf76miW0ebmamLhoIZkLAadLJPO5EHeSljwnbYDawffAeqiWnd8UR5Zi+cAzcWMEBtUT9GpBpg==}
     engines: {node: '>=4.7.2'}
-
-  contentful-sdk-core@9.2.0:
-    resolution: {integrity: sha512-cUvHbC2u8ouJHhG3tofQhUc0FAmM/QBcalYjiczMtFKrR77BW+eSPcPg+A9DQlhIP0UGcQ/knXxoJpBvrERXTA==}
-    engines: {node: '>=18'}
 
   contentful-sdk-core@9.4.5:
     resolution: {integrity: sha512-8eGTMO11LXFAiosaiV38bjvW6cjoQFtNE38pNtVilZTXpmGFinClljihH0eriv11Ispd4q82TqtsXMJPYD/C+A==}
@@ -2897,15 +2891,6 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
-  follow-redirects@1.15.9:
-    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
   follow-redirects@1.16.0:
     resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
@@ -2925,10 +2910,6 @@ packages:
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
-
-  form-data@4.0.1:
-    resolution: {integrity: sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==}
-    engines: {node: '>= 6'}
 
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
@@ -3530,9 +3511,6 @@ packages:
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
@@ -3764,10 +3742,6 @@ packages:
     resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
     engines: {node: '>=6'}
 
-  p-throttle@6.2.0:
-    resolution: {integrity: sha512-NCKkOVj6PZa6NiTmfvGilDdf6vO1rFCD3KDnkHko8dTOtkpk4cSR/VTAhhLMG9aiQ7/A9HYgEDNmxzf6hxzR3g==}
-    engines: {node: '>=18'}
-
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
@@ -3868,9 +3842,6 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
@@ -3878,10 +3849,6 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
-
-  qs@6.14.0:
-    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
-    engines: {node: '>=0.6'}
 
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
@@ -5786,9 +5753,6 @@ snapshots:
   '@rollup/rollup-linux-s390x-gnu@4.60.4':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.40.2':
-    optional: true
-
   '@rollup/rollup-linux-x64-gnu@4.60.4':
     optional: true
 
@@ -6313,14 +6277,6 @@ snapshots:
       - debug
       - supports-color
 
-  axios@1.9.0:
-    dependencies:
-      follow-redirects: 1.15.9
-      form-data: 4.0.1
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   babel-plugin-react-compiler@19.0.0-beta-e993439-20250328:
     dependencies:
       '@babel/types': 7.26.9
@@ -6530,12 +6486,24 @@ snapshots:
   contentful-management@11.52.2:
     dependencies:
       '@contentful/rich-text-types': 16.8.5
-      axios: 1.9.0
-      contentful-sdk-core: 9.2.0
+      axios: 1.16.1
+      contentful-sdk-core: 9.4.5
       fast-copy: 3.0.2
       globals: 15.15.0
     transitivePeerDependencies:
       - debug
+      - supports-color
+
+  contentful-management@11.76.0:
+    dependencies:
+      '@contentful/rich-text-types': 16.8.5
+      axios: 1.16.1
+      contentful-sdk-core: 9.4.5
+      fast-copy: 3.0.2
+      globals: 15.15.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   contentful-management@12.5.0:
     dependencies:
@@ -6557,16 +6525,6 @@ snapshots:
     dependencies:
       fast-copy: 3.0.2
 
-  contentful-sdk-core@9.2.0:
-    dependencies:
-      fast-copy: 3.0.2
-      lodash: 4.17.21
-      p-throttle: 6.2.0
-      process: 0.11.10
-      qs: 6.14.0
-    optionalDependencies:
-      '@rollup/rollup-linux-x64-gnu': 4.40.2
-
   contentful-sdk-core@9.4.5:
     dependencies:
       fast-copy: 3.0.2
@@ -6574,7 +6532,7 @@ snapshots:
       process: 0.11.10
       qs: 6.15.2
     optionalDependencies:
-      '@rollup/rollup-linux-x64-gnu': 4.40.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.4
 
   contentful@11.12.2:
     dependencies:
@@ -6594,13 +6552,14 @@ snapshots:
     dependencies:
       '@contentful/content-source-maps': 0.11.19
       '@contentful/rich-text-types': 16.8.5
-      axios: 1.9.0
+      axios: 1.16.1
       contentful-resolve-response: 1.9.3
-      contentful-sdk-core: 9.2.0
+      contentful-sdk-core: 9.4.5
       json-stringify-safe: 5.0.1
       type-fest: 4.41.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   convert-source-map@2.0.0: {}
 
@@ -7151,8 +7110,6 @@ snapshots:
 
   flatted@3.3.3: {}
 
-  follow-redirects@1.15.9: {}
-
   follow-redirects@1.16.0: {}
 
   for-each@0.3.5:
@@ -7165,12 +7122,6 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
-
-  form-data@4.0.1:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      mime-types: 2.1.35
 
   form-data@4.0.5:
     dependencies:
@@ -7773,8 +7724,6 @@ snapshots:
 
   lodash.startcase@4.4.0: {}
 
-  lodash@4.17.21: {}
-
   lodash@4.18.1: {}
 
   log-symbols@1.0.2:
@@ -7992,8 +7941,6 @@ snapshots:
 
   p-map@2.1.0: {}
 
-  p-throttle@6.2.0: {}
-
   package-json-from-dist@1.0.1: {}
 
   parse5@7.3.0:
@@ -8080,15 +8027,9 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
-  proxy-from-env@1.1.0: {}
-
   proxy-from-env@2.1.0: {}
 
   punycode@2.3.1: {}
-
-  qs@6.14.0:
-    dependencies:
-      side-channel: 1.1.0
 
   qs@6.15.2:
     dependencies:


### PR DESCRIPTION
## Summary

- Idempotent seed script (`apps/web/scripts/seed-contentful.mjs`) for the master Contentful env
- New devDep `contentful-management`, new pnpm script `seed`
- Bug fix in `getButtonUrl` — normalizes slug so internal page references resolve whether editors store slugs as `/about` or `about`

## What gets seeded

- 6 marketing pages: `/about`, `/careers`, `/contact`, `/features`, `/pricing`, `/home-demo`
- 6 blog posts with authors, cover images, richText body, and a footer CTA
- 3 authors with avatars
- 13 Unsplash assets (uploaded, processed, published)
- All supporting pageBuilder blocks: 6 heroes, 7 feature cards, 3 feature-card groups, 6 FAQs, 2 FAQ accordions, 5 CTAs, 3 reusable buttons

The existing `/` and `/dev` pages are untouched. The seeded home composition lives at `/home-demo` to avoid clobbering production.

## Running it

```bash
pnpm --filter web seed                       # default: publish
SEED_PUBLISH=false pnpm --filter web seed    # drafts only
```

Deterministic IDs (`seed-*` prefix) make the script re-runnable: unchanged entries log `exists`, drifted fields trigger update + republish, and broken assets self-heal (drop + recreate).

## Verified live

| URL | Status |
| --- | --- |
| `/about` | renders seeded hero |
| `/careers` | renders seeded hero |
| `/pricing` | renders seeded hero |
| `/features` | renders seeded hero |
| `/contact` | renders seeded hero |
| `/home-demo` | full 4-block composition |

## Why the slug fix was needed

The catch-all `[...slug]/page.tsx` queries `getPageBySlug("/about")` (leading slash). Existing pages on the space (`/` and `/dev`) use the leading-slash convention, but `getButtonUrl` was prepending a slash unconditionally — `/${slug}` produced `//about` when an editor stored the slug as `/about`. Now strips an optional leading slash first, so both conventions work.

## Test plan

- [ ] `pnpm --filter web seed` runs cleanly on a fresh checkout
- [ ] Re-running reports `exists` for all entries
- [ ] /about, /careers, /pricing, /features, /contact render with their seeded hero
- [ ] /home-demo renders hero + feature cards + FAQ + CTA
- [ ] Internal-reference buttons resolve regardless of leading slash in the slug field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed internal link URL formatting by normalizing slug values, ensuring consistent navigation paths throughout the application.

* **Chores**
  * Enhanced deployment workflows with automated content seeding capabilities, enabling efficient creation and updates of content entries and assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->