### PR TITLE
Add license section with Roboto Studio link

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,3 +167,7 @@ The project uses Tailwind CSS with a shared configuration. Customize `tailwind.c
 ## Contributing
 
 Contributions are welcome! Please read our contributing guidelines and code of conduct before submitting pull requests.
+
+## License
+
+[MIT](LICENSE) &copy; [Roboto Studio](https://robotostudio.com)


### PR DESCRIPTION
The repo ships an MIT LICENSE but the README never mentioned it and had no link back to robotostudio.com. Adds the standard license footer used by the other turbo-start repos.

Fixes part of ROB-2081

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added License section to README with MIT license attribution and copyright information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->