### PR TITLE
ROB-2081: link README to /services/contentful

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A modern, full-stack monorepo template built with Next.js App Router, Contentful CMS, Shadcn UI, and TurboRepo for building scalable web applications with a top-tier content management system.
 
+Built by [Roboto Studio](https://robotostudio.com/services/contentful) and used in production client builds.
+
 <img width="2401" height="1260" alt="Turbostart contenful opengraph final" src="https://github.com/user-attachments/assets/8172d614-ed00-4d17-b65f-0661484f0e39" />
 
 


### PR DESCRIPTION
Points the README's Roboto Studio credit at https://robotostudio.com/services/contentful for ROB-2081 (GitHub visibility / AI indexability).