### PR TITLE
Refactor : Standardise central content container

### DIFF
--- a/.cursor/rules/contentful-component-template.mdc
+++ b/.cursor/rules/contentful-component-template.mdc
@@ -42,7 +42,7 @@ export function [ComponentName](mdc:props: [ComponentName]Props) {
 
   return (
     <section id="[section-id]" className="my-6 md:my-16">
-      <div className="container mx-auto px-4 md:px-6">
+      <div className="container">
         {/* Apply inspector props to each editable field */}
         <h2
           className="text-3xl font-semibold md:text-5xl"
@@ -236,12 +236,15 @@ Use consistent section structure:
 ```typescript
 return (
   <section id="[unique-id]" className="my-6 md:my-16">
-    <div className="container mx-auto px-4 md:px-6">
+    <div className="container">
       {/* Content here */}
     </div>
   </section>
 );
 ```
+
+The shared `container` utility (`packages/ui/src/styles/globals.css`) already applies
+`mx-auto` and the `px-4 md:px-6` gutters — use `container` alone, don't repeat them.
 
 ### 8. Conditional Rendering Pattern
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ CONTENTFUL_MANAGEMENT_TOKEN          # typegen only
 ## Component Conventions
 
 From `.cursor/rules/`:
-- **New Contentful sections**: follow the Live Preview pattern above and the template in `.cursor/rules/contentful-component-template.mdc`. Section files live in `apps/web/src/components/sections/`, kebab-case (`feature-cards-with-icon.tsx`), `PascalCase` exports, props type `[Component]Props = TypeXxx<"WITHOUT_UNRESOLVABLE_LINKS">`. Wrap in `<section id="…" className="my-6 md:my-16">` with a `container mx-auto px-4 md:px-6` inner div.
+- **New Contentful sections**: follow the Live Preview pattern above and the template in `.cursor/rules/contentful-component-template.mdc`. Section files live in `apps/web/src/components/sections/`, kebab-case (`feature-cards-with-icon.tsx`), `PascalCase` exports, props type `[Component]Props = TypeXxx<"WITHOUT_UNRESOLVABLE_LINKS">`. Wrap in `<section id="…" className="my-6 md:my-16">` with a `container` inner div — the shared `container` utility (`packages/ui/src/styles/globals.css`) already centres and applies the `px-4 md:px-6` gutters, so don't add `mx-auto`/padding.
 - **Layout primitives** (`frontend-rules.mdc`): prefer `grid` over `flex` except for simple parent-child rows; use semantic HTML; route all button rendering through `ContentfulButtons` (`apps/web/src/components/contentful-button.tsx`); images through `ContentfulImage`.
 - **Shared UI**: import from `@workspace/ui/components/<name>` — don't duplicate Shadcn components into the app.
 

--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -59,7 +59,7 @@ export default async function BlogSlugPage({
   const { title, description, image, richText } = blog?.fields ?? {};
 
   return (
-    <div className="container my-16 mt-24 md:mt-32 mx-auto px-4 md:px-6">
+    <div className="container my-16 mt-24 md:mt-32">
       <div className="grid grid-cols-1 gap-8 lg:grid-cols-[1fr_300px]">
         <main>
           <ArticleJsonLd article={blog} />

--- a/apps/web/src/app/blog/page.tsx
+++ b/apps/web/src/app/blog/page.tsx
@@ -24,7 +24,7 @@ export default async function BlogIndexPage() {
   if (!result.success) {
     return (
       <main className="min-h-screen">
-        <div className="container mx-auto px-4 py-24 pt-32 md:px-6">
+        <div className="container py-24 pt-32">
           <BlogHeader title="Blog" description="Blog" />
           <div className="mt-8 text-center text-gray-400">Not Found</div>
         </div>
@@ -35,7 +35,7 @@ export default async function BlogIndexPage() {
 
   return (
     <main className="min-h-screen">
-      <div className="container mx-auto px-4 py-24 pt-32 md:px-6">
+      <div className="container py-24 pt-32">
         <BlogHeader title="Blog" description="Blog" />
         <div className="mt-12">
           {featured && <FeaturedBlogCard blog={featured} />}

--- a/apps/web/src/components/blog-card.tsx
+++ b/apps/web/src/components/blog-card.tsx
@@ -209,13 +209,11 @@ export function BlogHeader({
   description: string | null;
 }) {
   return (
-    <div className="mx-auto max-w-7xl px-6 lg:px-8">
-      <div className="mx-auto max-w-2xl text-center">
-        <h1 className="text-3xl font-bold sm:text-4xl">{title}</h1>
-        <p className="mt-4 text-lg leading-8 text-muted-foreground">
-          {description}
-        </p>
-      </div>
+    <div className="mx-auto max-w-2xl text-center">
+      <h1 className="text-3xl font-bold sm:text-4xl">{title}</h1>
+      <p className="mt-4 text-lg leading-8 text-muted-foreground">
+        {description}
+      </p>
     </div>
   );
 }

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -73,7 +73,7 @@ function SocialLinks({ settingsData }: { settingsData: GlobalSettings }) {
 export function FooterSkeleton() {
   return (
     <section className="mt-16 pb-8">
-      <div className="container mx-auto px-4 md:px-6">
+      <div className="container">
         <footer className="h-[500px] lg:h-auto">
           <div className="flex flex-col items-center justify-between gap-10 text-center lg:flex-row lg:text-left">
             <div className="flex w-full max-w-96 shrink flex-col items-center justify-between gap-6 lg:items-start">
@@ -129,94 +129,89 @@ function Footer({ settingsData }: { settingsData: GlobalSettings }) {
 
   return (
     <section className="mt-20 pb-8">
-      <div className="container mx-auto">
-        <footer className="h-[500px] lg:h-auto">
-          <div className="flex flex-col items-center justify-between gap-10 text-center lg:flex-row lg:text-left mx-auto px-4 md:px-6">
-            <div className="flex w-full max-w-96 shrink flex-col items-center justify-between gap-6 md:gap-8 lg:items-start">
-              <div>
-                <span className="flex items-center justify-center gap-4 lg:justify-start">
-                  <Logo logo={logo} alt={siteTitle} />
-                </span>
-                {footerLabel && (
-                  <p className="mt-6 text-sm text-muted-foreground dark:text-zinc-400">
-                    {footerLabel}
-                  </p>
-                )}
-              </div>
-              <SocialLinks settingsData={settingsData} />
+      <footer className="h-[500px] lg:h-auto">
+        <div className="container flex flex-col items-center justify-between gap-10 text-center lg:flex-row lg:text-left">
+          <div className="flex w-full max-w-96 shrink flex-col items-center justify-between gap-6 md:gap-8 lg:items-start">
+            <div>
+              <span className="flex items-center justify-center gap-4 lg:justify-start">
+                <Logo logo={logo} alt={siteTitle} />
+              </span>
+              {footerLabel && (
+                <p className="mt-6 text-sm text-muted-foreground dark:text-zinc-400">
+                  {footerLabel}
+                </p>
+              )}
             </div>
-            {Array.isArray(columns) && columns?.length > 0 && (
-              <div className="grid grid-cols-3 gap-6 lg:gap-28 lg:mr-20">
-                {columns.map((column, index) => {
-                  if (!column?.fields) return null;
-                  return (
-                    <div key={`column-${column.sys.id}-${index}`}>
-                      <h2 className="mb-6 font-semibold">
-                        {column.fields.label}
-                      </h2>
-                      {column.fields.links &&
-                        column.fields.links.length > 0 && (
-                          <ul className="space-y-4 text-sm text-muted-foreground dark:text-zinc-400">
-                            {column.fields.links.map(
-                              (link: FooterLinkType, linkIndex) => {
-                                if (!link?.fields) return null;
-                                return (
-                                  <li
-                                    key={`${link.sys.id}-${linkIndex}-column-${column.sys.id}`}
-                                    className="font-medium hover:text-primary"
-                                  >
-                                    <Link
-                                      href={link.fields.href ?? "#"}
-                                      target={
-                                        link.fields.internal
-                                          ? undefined
-                                          : "_blank"
-                                      }
-                                      rel={
-                                        link.fields.internal
-                                          ? undefined
-                                          : "noopener noreferrer"
-                                      }
-                                    >
-                                      {link.fields.label}
-                                    </Link>
-                                  </li>
-                                );
-                              },
-                            )}
-                          </ul>
+            <SocialLinks settingsData={settingsData} />
+          </div>
+          {Array.isArray(columns) && columns?.length > 0 && (
+            <div className="grid grid-cols-3 gap-6 lg:gap-28 lg:mr-20">
+              {columns.map((column, index) => {
+                if (!column?.fields) return null;
+                return (
+                  <div key={`column-${column.sys.id}-${index}`}>
+                    <h2 className="mb-6 font-semibold">
+                      {column.fields.label}
+                    </h2>
+                    {column.fields.links && column.fields.links.length > 0 && (
+                      <ul className="space-y-4 text-sm text-muted-foreground dark:text-zinc-400">
+                        {column.fields.links.map(
+                          (link: FooterLinkType, linkIndex) => {
+                            if (!link?.fields) return null;
+                            return (
+                              <li
+                                key={`${link.sys.id}-${linkIndex}-column-${column.sys.id}`}
+                                className="font-medium hover:text-primary"
+                              >
+                                <Link
+                                  href={link.fields.href ?? "#"}
+                                  target={
+                                    link.fields.internal ? undefined : "_blank"
+                                  }
+                                  rel={
+                                    link.fields.internal
+                                      ? undefined
+                                      : "noopener noreferrer"
+                                  }
+                                >
+                                  {link.fields.label}
+                                </Link>
+                              </li>
+                            );
+                          },
                         )}
-                    </div>
-                  );
-                })}
-              </div>
-            )}
-          </div>
-          <div className="mt-40 pt-8">
-            <div className="flex flex-col justify-between gap-4 text-center lg:flex-row lg:items-center lg:text-left mx-auto px-4 md:px-6 font-mono uppercase text-zinc-600 dark:text-zinc-400 text-sm">
-              <p>POWERED BY VERCEL & CONTENTFUL</p>
-              <div className="relative">
-                <Link
-                  href={"https://robotostudio.com"}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-zinc-950 dark:text-zinc-50"
-                >
-                  {siteTitle}
-                </Link>
-                <Image
-                  src={"/footer-logo.svg"}
-                  alt="Powered by Robotostudio"
-                  width={264}
-                  height={226}
-                  className="absolute top-[-90%] left-[50%] lg:left-[58%] -translate-x-1/2 -translate-y-1/2 min-w-64 select-none pointer-events-none"
-                />
-              </div>
-              <p>© {year} TURBO START Contentful</p>
+                      </ul>
+                    )}
+                  </div>
+                );
+              })}
             </div>
+          )}
+        </div>
+        <div className="mt-40 pt-8">
+          <div className="container flex flex-col justify-between gap-4 text-center lg:flex-row lg:items-center lg:text-left font-mono uppercase text-zinc-600 dark:text-zinc-400 text-sm">
+            <p>POWERED BY VERCEL & CONTENTFUL</p>
+            <div className="relative">
+              <Link
+                href={"https://robotostudio.com"}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-zinc-950 dark:text-zinc-50"
+              >
+                {siteTitle}
+              </Link>
+              <Image
+                src={"/footer-logo.svg"}
+                alt="Powered by Robotostudio"
+                width={264}
+                height={226}
+                className="absolute top-[-90%] left-[50%] lg:left-[58%] -translate-x-1/2 -translate-y-1/2 min-w-64 select-none pointer-events-none"
+              />
+            </div>
+            <p>© {year} TURBO START Contentful</p>
           </div>
-        </footer>
-      </div>
+        </div>
+      </footer>
     </section>
   );
 }

--- a/apps/web/src/components/navbar-client.tsx
+++ b/apps/web/src/components/navbar-client.tsx
@@ -346,7 +346,7 @@ const ClientSideNavbar = ({
         isScrolled && "border bg-background",
       )}
     >
-      <div className="container mx-auto px-4 md:px-6">
+      <div className="container">
         <nav className="flex items-center justify-between gap-4">
           {isMobile ? (
             <MobileNavbar settingsData={settingsData} />
@@ -402,7 +402,7 @@ function SkeletonDesktopNavbar() {
 export function NavbarSkeletonResponsive() {
   return (
     <motion.section className="py-3 z-20 fixed top-0 inset-x-0">
-      <div className="container mx-auto px-4 md:px-6">
+      <div className="container">
         <nav className="flex items-center justify-between gap-4">
           <SkeletonMobileNavbar />
           <SkeletonDesktopNavbar />

--- a/apps/web/src/components/sections/cta.tsx
+++ b/apps/web/src/components/sections/cta.tsx
@@ -32,7 +32,7 @@ export function CTABlock(props: CTABlockProps) {
 
   return (
     <section id="cta" className="my-6 md:my-16">
-      <div className="container relative max-w-5xl mx-auto px-4 md:px-6">
+      <div className="relative max-w-5xl mx-auto px-4 md:px-6">
         <div className="bg-[url('/cta-bg.png')] bg-cover bg-center py-16 rounded-2xl px-4 relative z-10">
           <div className="text-center max-w-3xl mx-auto">
             {eyebrow && (

--- a/apps/web/src/components/sections/faq-accordion.tsx
+++ b/apps/web/src/components/sections/faq-accordion.tsx
@@ -27,7 +27,7 @@ export function FaqAccordion(props: FaqAccordionProps) {
   });
   return (
     <section id="faq" className="my-8 md:my-14 relative">
-      <div className="container relative mx-auto px-4 md:px-6">
+      <div className="container relative">
         <div className="flex w-full flex-col items-center relative z-10">
           <div className="flex flex-col items-center space-y-4 text-center sm:space-y-6 md:text-center">
             <Badge {...inspectorProps({ fieldId: "eyebrow" })}>{eyebrow}</Badge>

--- a/apps/web/src/components/sections/feature-cards-with-icon.tsx
+++ b/apps/web/src/components/sections/feature-cards-with-icon.tsx
@@ -117,7 +117,7 @@ export function FeatureCardsWithIcon(props: FeatureCardsWithIconProps) {
 
   return (
     <section id="features" className="my-6 md:my-14 mx-auto">
-      <div className="container relative mx-auto px-4 md:px-6">
+      <div className="container relative">
         <div className="flex flex-col items-center z-1">
           <div className="flex flex-col items-center space-y-4 text-center sm:space-y-6 md:text-center">
             {eyebrow && (

--- a/apps/web/src/components/sections/hero.tsx
+++ b/apps/web/src/components/sections/hero.tsx
@@ -42,7 +42,7 @@ export function HeroBlock(props: HeroBlockProps) {
       <div className="absolute z-1 inset-0 rounded-full bg-zinc-100 dark:bg-zinc-900 blur-[250px] pointer-events-none" />
       <div className="absolute -bottom-20 -inset-x-10 h-[180px] bg-[linear-gradient(90deg,_rgba(250,250,250,0.8)_0%,_#FAFAFA_50%,_rgba(250,250,250,1)_100%)] dark:bg-[linear-gradient(90deg,_rgba(0,0,0,0.8)_0%,_rgba(0,0,0,0.8)_50%,_rgba(0,0,0,1)_100%)] blur-[40px] pointer-events-none z-5" />
 
-      <div className="container relative z-10 mx-auto px-4 md:px-6">
+      <div className="container relative z-10">
         <div className="grid place-items-center gap-8 lg:grid-cols-2">
           <div className="grid h-full items-center justify-items-center text-center lg:items-start lg:justify-items-start lg:text-left">
             {badge && (

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -8,12 +8,8 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
-/* Single source of truth for the central content rail (ROB-2104).
- * Overrides Tailwind's built-in `container`. Both rules are emitted; this
- * max-width wins by source order (equal specificity), not by replacement —
- * correct on the pinned Tailwind version. If a Tailwind upgrade reorders
- * emission, the built-in's larger 2xl max-width could reassert; revisit (or
- * rename to a distinct utility) when upgrading. */
+/* Central content rail. Overrides Tailwind's built-in `container` by source
+ * order (equal specificity) — revisit on a Tailwind upgrade. */
 @utility container {
   @apply mx-auto w-full max-w-7xl px-4 md:px-6;
 }

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -8,6 +8,16 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
+/* Single source of truth for the central content rail (ROB-2104).
+ * Overrides Tailwind's built-in `container`. Both rules are emitted; this
+ * max-width wins by source order (equal specificity), not by replacement —
+ * correct on the pinned Tailwind version. If a Tailwind upgrade reorders
+ * emission, the built-in's larger 2xl max-width could reassert; revisit (or
+ * rename to a distinct utility) when upgrading. */
+@utility container {
+  @apply mx-auto w-full max-w-7xl px-4 md:px-6;
+}
+
 @theme {
   --font-geist: var(--font-geist), ui-sans-serif, system-ui, sans-serif;
   --font-mono: var(--font-mono), ui-monospace, monospace;


### PR DESCRIPTION
## Problem / Intent

The site had no shared definition for its central content rail. The navbar, page-builder sections, footer, and blog pages each hand-rolled their own `container mx-auto px-4 md:px-6` (or diverged from it entirely), so `container` fell through to Tailwind's default responsive max-widths and gutters didn't line up between the nav, content, and footer. This change (ROB-2104) establishes one shared container definition and applies it everywhere so all three align.

## Summary

- Overrode Tailwind's built-in `container` utility with a single fixed rail — `max-width: 80rem` (`max-w-7xl`), centered, `px-4` / `md:px-6` gutters — in the shared theme, making it the one source of truth every `container` usage inherits site-wide (computed: `max-width: 1280px`, `padding-inline: 24px` at ≥`md`).
- Normalised every rail call site to bare `container`, shedding the now-redundant `mx-auto` / `px-*` / `max-w-*` classes across the navbar, footer, all page-builder sections, and the blog index/post pages.
- Restructured the footer: dropped the outer wrapper and moved the rail onto the content row and the bottom-bar divider, so both align to the same gutters as the nav.
- Fixed two stray rails: CTA keeps its narrower `max-w-5xl` card (now via an explicit rail rather than fighting `container`), and `BlogHeader` lost its redundant nested `max-w-7xl px-6 lg:px-8` since it always renders inside a page `container`.

## Core file changes

| File                                                                                | Change                                                                                                                                                                                                                     |
| ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `packages/ui/src/styles/globals.css`                                                | Adds `@utility container { @apply mx-auto w-full max-w-7xl px-4 md:px-6; }` overriding Tailwind's default — the single rail definition. Comment notes the override wins by source order, to revisit on a Tailwind upgrade. |
| `apps/web/src/components/navbar-client.tsx`                                         | Header + skeleton rails simplified from `container mx-auto px-4 md:px-6` to bare `container`.                                                                                                                              |
| `apps/web/src/components/footer.tsx`                                                | Removed the outer container wrapper; rail moved onto the content row and bottom-bar divider as bare `container`.                                                                                                           |
| `apps/web/src/components/blog-card.tsx`                                             | `BlogHeader` no longer wraps content in a redundant `max-w-7xl px-6 lg:px-8` rail.                                                                                                                                         |
| `apps/web/src/components/sections/{hero,feature-cards-with-icon,faq-accordion}.tsx` | Inner rail `container mx-auto px-4 md:px-6` → bare `container`.                                                                                                                                                            |
| `apps/web/src/components/sections/cta.tsx`                                          | Dropped `container` from the capped card so its `max-w-5xl` rail stays intentional (not overridden by the 80rem container).                                                                                                |
| `apps/web/src/app/blog/page.tsx`, `apps/web/src/app/blog/[slug]/page.tsx`           | Page rails normalised to bare `container` (kept vertical spacing on the wrapper).                                                                                                                                          |

## Preview

<img width="1802" height="926" alt="image" src="https://github.com/user-attachments/assets/c25b6107-141a-4fdb-9a8e-8ef0812de628" />


## Verification

- [x] `pnpm --filter web check-types`
- [x] `pnpm --filter web lint`
- [x] `pnpm build`
- [x] Load `/`, a content page, `/blog`, and `/blog/<slug>`; confirm the navbar, section content, and footer share the same left/right gutter at mobile, `md`, and wide (>80rem) widths.
- [x] Inspect a `.container` element: computed `max-width` is `1280px`, centered (`margin-inline: auto`), `padding-inline` `16px` (mobile) / `24px` (≥`md`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes / Improvements**
  * Standardized spacing and alignment across the blog pages and key layout sections (hero, CTA, FAQ, feature cards, navbar, and footer), including consistent container behavior.
  * Updated layout wrappers for both normal and fallback (“not found”/skeleton) render states to keep horizontal centering and padding consistent.
  * Introduced an app-wide Tailwind `container` utility to control the central content rail’s width and padding consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->