### PR TITLE
Refactor: Simplify OG image to site-name + title layout

### DIFF
--- a/apps/web/src/app/api/og/route.tsx
+++ b/apps/web/src/app/api/og/route.tsx
@@ -7,6 +7,7 @@ import { cache } from "react";
 
 import {
   getBlogByID,
+  getGlobalSettings,
   getPageByID,
   getPageBySlug,
 } from "@/lib/contentful/query";
@@ -34,14 +35,10 @@ type SeoImageRenderProps = {
 
 type ContentProps = Record<string, string>;
 
-type DominantColorSeoImageRenderProps = {
-  image?: string | null | undefined;
+type SimpleOgRenderProps = {
   title?: string | null | undefined;
-  logo?: string | null | undefined;
-  dominantColor?: string | null | undefined;
-  date?: string | null | undefined;
   _type?: string | null | undefined;
-  description?: string | null | undefined;
+  siteTitle?: string | null | undefined;
 };
 
 const seoImageRender = ({ seoImage }: SeoImageRenderProps) => {
@@ -52,90 +49,37 @@ const seoImageRender = ({ seoImage }: SeoImageRenderProps) => {
   );
 };
 
-const dominantColorSeoImageRender = ({
-  image,
-  title,
-  logo,
-  date,
-  description,
-  _type,
-}: DominantColorSeoImageRenderProps) => {
+const simpleOgRender = ({ title, _type, siteTitle }: SimpleOgRenderProps) => {
   return (
     <div
-      tw={`bg-[${"#12061F"}] flex flex-row overflow-hidden relative w-full`}
-      style={{ fontFamily: "Inter" }}
+      style={{ backgroundColor: "#0A0A0A", fontFamily: "Inter" }}
+      tw="flex flex-col justify-between w-full h-full p-[70px]"
     >
-      <svg
-        width="100%"
-        height="100%"
-        style={{ position: "absolute", top: 0, left: 0 }}
-        aria-hidden="true"
-      >
-        <defs>
-          <linearGradient id="gradient" x1="0%" y1="100%" x2="100%" y2="0%">
-            <stop offset="0%" style={{ stopColor: "transparent" }} />
-            <stop offset="100%" style={{ stopColor: "white" }} />
-          </linearGradient>
-        </defs>
-        <rect width="100%" height="100%" fill="url(#gradient)" opacity="0.2" />
-      </svg>
-
-      <div tw="flex-1 p-10 flex flex-col justify-between relative z-10">
-        <div tw="flex justify-between items-start w-full">
-          {logo && <img src={logo} alt="Logo" height={48} />}
-          <div tw="bg-white flex bg-opacity-20 text-white px-4 py-2 rounded-full text-sm font-medium">
-            {new Date(date ?? new Date()).toLocaleDateString("en-US", {
-              month: "long",
-              day: "numeric",
-              year: "numeric",
-            })}
-          </div>
+      <div tw="flex items-center justify-between w-full">
+        <div tw="flex text-white text-2xl font-semibold">
+          {siteTitle ?? "Turbo Start Contentful"}
         </div>
-
-        <h1 tw="text-5xl font-bold leading-tight max-w-[90%] text-white">
-          {title}
-        </h1>
-        {description && <p tw="text-lg text-white">{description}</p>}
-        {_type && (
+        {/* Type pill: blog posts only */}
+        {_type === "blog" && (
           <div
-            tw={`bg-white text-[${"#12061F"}] flex px-5 py-2 rounded-full text-base font-semibold self-start`}
+            style={{
+              borderColor: "#ffffff",
+              letterSpacing: "0.1em",
+              textTransform: "uppercase",
+            }}
+            tw="flex border text-white px-6 py-3 rounded-full text-xl font-medium"
           >
             {getTitleCase(_type)}
           </div>
         )}
       </div>
 
-      <div tw="w-[630px] h-[630px] flex items-center justify-center p-8 relative z-10">
-        <div tw="w-[566px] h-[566px] bg-white bg-opacity-20 flex flex-col justify-center items-center rounded-3xl shadow-[0_0_0_1px_rgba(255,255,255,0.05),0_2px_4px_-1px_rgba(0,0,0,0.03),0_4px_6px_-1px_rgba(0,0,0,0.05),0_8px_10px_-1px_rgba(0,0,0,0.05)] overflow-hidden">
-          <div tw="flex relative w-full h-full">
-            {image ? (
-              <img
-                src={image}
-                tw="w-full h-full rounded-3xl shadow-2xl"
-                width={566}
-                height={566}
-                alt="Content preview"
-                style={{
-                  objectFit: "cover",
-                }}
-              />
-            ) : logo ? (
-              <div tw="flex items-center justify-center h-full w-full">
-                <img src={logo} alt="Logo" width={400} height={400} />
-              </div>
-            ) : (
-              <div tw="flex items-center justify-center h-full w-full">
-                <img
-                  src={"https://picsum.photos/566/566"}
-                  alt="Logo"
-                  width={400}
-                  height={400}
-                />
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
+      <h1
+        style={{ lineHeight: 1.05, letterSpacing: "-0.02em", fontWeight: 400 }}
+        tw="flex text-[76px] max-w-[90%] text-white"
+      >
+        {title ?? siteTitle ?? "Turbo Start Contentful"}
+      </h1>
     </div>
   );
 };
@@ -209,6 +153,12 @@ const getOptions = cache(
   },
 );
 
+const getSiteTitle = async () => {
+  const result = await safeAsync(getGlobalSettings());
+  if (!result.success) return undefined;
+  return result.data?.fields?.siteTitle;
+};
+
 const getHomePageContent = async () => {
   const result = await safeAsync(getPageBySlug("/"));
   if (!result.success) {
@@ -216,20 +166,14 @@ const getHomePageContent = async () => {
     return undefined;
   }
   const page = result.data;
-  const { seoImage, image, title } = page?.fields ?? {};
+  const { seoImage, title } = page?.fields ?? {};
 
   const seoImageUrl = getImageUrl(
     seoImage as Asset<"WITHOUT_UNRESOLVABLE_LINKS", string>,
   );
   if (seoImageUrl) return seoImageRender({ seoImage: seoImageUrl.url });
-  const imageUrl = getImageUrl(
-    image as Asset<"WITHOUT_UNRESOLVABLE_LINKS", string>,
-  );
-  return dominantColorSeoImageRender({
-    image: imageUrl?.url,
-    title,
-    _type: "page",
-  });
+  const siteTitle = await getSiteTitle();
+  return simpleOgRender({ title, _type: "page", siteTitle });
 };
 
 const getSlugPageContent = async ({ id }: ContentProps) => {
@@ -240,21 +184,12 @@ const getSlugPageContent = async ({ id }: ContentProps) => {
     return undefined;
   }
   const page = result.data;
-  const { seoImage, image, title, description } = page?.fields ?? {};
+  const { seoImage, title } = page?.fields ?? {};
 
   const seoImageUrl = getImageUrl(seoImage);
-
   if (seoImageUrl) return seoImageRender({ seoImage: seoImageUrl.url });
-  const imageUrl = getImageUrl(image);
-  if (imageUrl) {
-    return dominantColorSeoImageRender({
-      image: imageUrl.url,
-      title,
-      description,
-      _type: "page",
-    });
-  }
-  return errorContent;
+  const siteTitle = await getSiteTitle();
+  return simpleOgRender({ title, _type: "page", siteTitle });
 };
 
 const getBlogPageContent = async ({ id }: ContentProps) => {
@@ -265,20 +200,11 @@ const getBlogPageContent = async ({ id }: ContentProps) => {
     return undefined;
   }
   const blog = result.data;
-  const { seoImage, image, title, description } = blog?.fields ?? {};
+  const { seoImage, title } = blog?.fields ?? {};
   const seoImageUrl = getImageUrl(seoImage);
   if (seoImageUrl) return seoImageRender({ seoImage: seoImageUrl.url });
-  const imageUrl = getImageUrl(image);
-  if (imageUrl) {
-    return dominantColorSeoImageRender({
-      image: imageUrl.url,
-      title,
-      description,
-      _type: "blog",
-      date: new Date(blog?.fields?.publishedDate ?? new Date()).toISOString(),
-    });
-  }
-  return errorContent;
+  const siteTitle = await getSiteTitle();
+  return simpleOgRender({ title, _type: "blog", siteTitle });
 };
 
 const block = {

--- a/apps/web/src/app/api/og/route.tsx
+++ b/apps/web/src/app/api/og/route.tsx
@@ -57,7 +57,7 @@ const simpleOgRender = ({ title, _type, siteTitle }: SimpleOgRenderProps) => {
     >
       <div tw="flex items-center justify-between w-full">
         <div tw="flex text-white text-2xl font-semibold">
-          {siteTitle ?? "Turbo Start Contentful"}
+          {siteTitle || "Turbo Start Contentful"}
         </div>
         {/* Type pill: blog posts only */}
         {_type === "blog" && (
@@ -78,7 +78,7 @@ const simpleOgRender = ({ title, _type, siteTitle }: SimpleOgRenderProps) => {
         style={{ lineHeight: 1.05, letterSpacing: "-0.02em", fontWeight: 400 }}
         tw="flex text-[76px] max-w-[90%] text-white"
       >
-        {title ?? siteTitle ?? "Turbo Start Contentful"}
+        {title || siteTitle || "Turbo Start Contentful"}
       </h1>
     </div>
   );
@@ -159,21 +159,30 @@ const getSiteTitle = async () => {
   return result.data?.fields?.siteTitle;
 };
 
+// Serve an uploaded seoImage as-is, else the generated card with siteTitle.
+const renderOgContent = async (
+  seoImage: Asset<"WITHOUT_UNRESOLVABLE_LINKS", string> | undefined,
+  title: string | null | undefined,
+  _type: "page" | "blog",
+) => {
+  const seoImageUrl = getImageUrl(seoImage);
+  if (seoImageUrl) return seoImageRender({ seoImage: seoImageUrl.url });
+  const siteTitle = await getSiteTitle();
+  return simpleOgRender({ title, _type, siteTitle });
+};
+
 const getHomePageContent = async () => {
   const result = await safeAsync(getPageBySlug("/"));
   if (!result.success) {
     console.error("Failed to fetch home page for OG image:", result.error);
     return undefined;
   }
-  const page = result.data;
-  const { seoImage, title } = page?.fields ?? {};
-
-  const seoImageUrl = getImageUrl(
+  const { seoImage, title } = result.data?.fields ?? {};
+  return renderOgContent(
     seoImage as Asset<"WITHOUT_UNRESOLVABLE_LINKS", string>,
+    title,
+    "page",
   );
-  if (seoImageUrl) return seoImageRender({ seoImage: seoImageUrl.url });
-  const siteTitle = await getSiteTitle();
-  return simpleOgRender({ title, _type: "page", siteTitle });
 };
 
 const getSlugPageContent = async ({ id }: ContentProps) => {
@@ -183,13 +192,8 @@ const getSlugPageContent = async ({ id }: ContentProps) => {
     console.error("Failed to fetch page for OG image:", result.error);
     return undefined;
   }
-  const page = result.data;
-  const { seoImage, title } = page?.fields ?? {};
-
-  const seoImageUrl = getImageUrl(seoImage);
-  if (seoImageUrl) return seoImageRender({ seoImage: seoImageUrl.url });
-  const siteTitle = await getSiteTitle();
-  return simpleOgRender({ title, _type: "page", siteTitle });
+  const { seoImage, title } = result.data?.fields ?? {};
+  return renderOgContent(seoImage, title, "page");
 };
 
 const getBlogPageContent = async ({ id }: ContentProps) => {
@@ -199,12 +203,8 @@ const getBlogPageContent = async ({ id }: ContentProps) => {
     console.error("Failed to fetch blog for OG image:", result.error);
     return undefined;
   }
-  const blog = result.data;
-  const { seoImage, title } = blog?.fields ?? {};
-  const seoImageUrl = getImageUrl(seoImage);
-  if (seoImageUrl) return seoImageRender({ seoImage: seoImageUrl.url });
-  const siteTitle = await getSiteTitle();
-  return simpleOgRender({ title, _type: "blog", siteTitle });
+  const { seoImage, title } = result.data?.fields ?? {};
+  return renderOgContent(seoImage, title, "blog");
 };
 
 const block = {

--- a/apps/web/src/app/api/og/route.tsx
+++ b/apps/web/src/app/api/og/route.tsx
@@ -178,11 +178,7 @@ const getHomePageContent = async () => {
     return undefined;
   }
   const { seoImage, title } = result.data?.fields ?? {};
-  return renderOgContent(
-    seoImage as Asset<"WITHOUT_UNRESOLVABLE_LINKS", string>,
-    title,
-    "page",
-  );
+  return renderOgContent(seoImage, title, "page");
 };
 
 const getSlugPageContent = async ({ id }: ContentProps) => {


### PR DESCRIPTION
## Problem / Intent

The generated Open Graph image (`/api/og`) used a busy "dominant-color" layout: a dark card with a gradient SVG overlay, a logo, a date pill, the description, a type badge, and a large rounded content-image card on the right — and it fetched the content image and logo on every request, falling back to a random `picsum.photos` image when none existed. Per ROB-2101, the goal is to simplify it to a clean, near-black canvas with just the site name, an optional type pill, and the title.

## Summary

- Replaced the generated OG design with a minimal layout: solid `#0A0A0A` background, the site name top-left, an outlined uppercase type pill top-right for blog posts (`BLOG`), and the title bottom-left at 76px. Long titles wrap and stay clear of the pill.
- Removed the dominant-color background, gradient SVG, date pill, description, and the right-side content-image card — dropping the remote content-image and logo fetches the route made on every request, and with them the `picsum.photos` fallback and the "Something went wrong" path that fired when those fetches failed.
- Made the top-left wordmark content-driven: the route now reads `siteTitle` from global settings (falling back to `"Turbo Start Contentful"`) instead of fetching the logo asset, so the brand name follows the CMS.
- Added a fallback for nullable titles (`title ?? siteTitle ?? "Turbo Start Contentful"`) so the hero line is never blank.
- Left the custom-`seoImage` override path (`seoImageRender`) untouched, so entries with an uploaded `seoImage` (e.g. the home page) still serve that image as-is instead of the generated design.

## Core file changes

| File                                | Change                                                                                                                                                                                                                                                                                                                                                                                                                                          |
| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `apps/web/src/app/api/og/route.tsx` | Rewrote the generated render (`dominantColorSeoImageRender` → `simpleOgRender`) to the minimal site-name + pill + title layout; deleted the gradient SVG, image card, `FallbackImage`/`picsum` helper, and the unused `image`/`logo`/`date`/`description`/`dominantColor` props. Resolvers now fetch `siteTitle` via `getGlobalSettings` and drop the content-image/date lookups; the `seoImage` override and Inter font loading are unchanged. |

## Preview

[**Preview Url**](https://turbo-start-contentful-git-rob-2128-starter-impro-65ae97-roboto.vercel.app/api/og?type=blog&id=3dUBDiVQ0Lc4Dcy9DYVV9Q)



<img width="1200" height="630" alt="og" src="https://github.com/user-attachments/assets/a4096fc9-593a-44bd-9efd-4c42f2386d22" />


## Verification

- [x] `pnpm --filter web check-types`
- [x] `pnpm --filter web lint`
- [x] Hit `/api/og?type=blog&id=<id>` → near-black canvas, site name top-left, outlined `BLOG` pill, title bottom-left; no `picsum` image, fonts render.
- [x] Hit `/api/og?type=home&id=<id>` (or any entry with an uploaded `seoImage`) → the uploaded image is served unchanged.
- [x] Confirm a page/blog `<head>` `og:image` / `twitter:image` resolves to the new image.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated social share (Open Graph) image generation to use a simpler, more consistent layout.
  * Share images now prioritize the existing SEO image; otherwise, they render a new template using the global site title plus the page/post title.
  * Blog posts include a small content-type label; non-blog pages omit it.
  * Homepage, slug, and blog OG rendering now follow the same simplified path for more reliable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->