### PR TITLE
FAQ: native details/summary + FAQPage JSON-LD

### DIFF
--- a/apps/web/src/app/[...slug]/page.tsx
+++ b/apps/web/src/app/[...slug]/page.tsx
@@ -1,6 +1,7 @@
 import { draftMode } from "next/headers";
 import { notFound } from "next/navigation";
 
+import { PageBuilderJsonLd } from "@/components/page-builder-json-ld";
 import { PageBuilder } from "@/components/pagebuilder";
 import { getPageBySlug } from "@/lib/contentful/query";
 import { getSEOMetadata } from "@/lib/seo";
@@ -70,5 +71,10 @@ export default async function CatchAllSlugPage({
     return <div>Error: {result.error.message}</div>;
   }
   const pageBuilder = result.data?.fields.pageBuilder;
-  return <PageBuilder pageBuilder={pageBuilder} />;
+  return (
+    <>
+      <PageBuilder pageBuilder={pageBuilder} />
+      <PageBuilderJsonLd pageBuilder={pageBuilder} />
+    </>
+  );
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,5 +1,6 @@
 import { draftMode } from "next/headers";
 
+import { PageBuilderJsonLd } from "@/components/page-builder-json-ld";
 import { PageBuilder } from "@/components/pagebuilder";
 import { getPageBySlug } from "@/lib/contentful/query";
 import { getSEOMetadata } from "@/lib/seo";
@@ -34,5 +35,10 @@ export default async function Page() {
     return <div>No page builder found</div>;
   }
 
-  return <PageBuilder pageBuilder={result.data.fields.pageBuilder} />;
+  return (
+    <>
+      <PageBuilder pageBuilder={result.data.fields.pageBuilder} />
+      <PageBuilderJsonLd pageBuilder={result.data.fields.pageBuilder} />
+    </>
+  );
 }

--- a/apps/web/src/components/json-ld.tsx
+++ b/apps/web/src/components/json-ld.tsx
@@ -15,12 +15,25 @@ import { getGlobalSettings } from "@/lib/contentful/query";
 import type { TypeBlog } from "@/lib/contentful/types";
 import { safeAsync } from "@/safe-async";
 
-// Utility function to safely render JSON-LD
+// Escape <, >, & to \uXXXX so a "</script>" in any CMS field can't break out of
+// the tag. JSON-LD is parsed as data (not executed), so escaping `<` is what
+// matters; the result stays valid JSON for crawlers.
+function serializeJsonLd<T>(data: T): string {
+  return JSON.stringify(data)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026");
+}
+
 export function JsonLdScript<T>({ data, id }: { data: T; id: string }) {
   return (
-    <script type="application/ld+json" id={id}>
-      {JSON.stringify(data, null, 0)}
-    </script>
+    <script
+      type="application/ld+json"
+      id={id}
+      // Raw injection so the JSON-LD reaches crawlers unescaped; serializeJsonLd
+      // already escapes <, >, & to prevent script breakout.
+      dangerouslySetInnerHTML={{ __html: serializeJsonLd(data) }}
+    />
   );
 }
 

--- a/apps/web/src/components/page-builder-json-ld.tsx
+++ b/apps/web/src/components/page-builder-json-ld.tsx
@@ -1,0 +1,46 @@
+import type { Entry } from "contentful";
+
+import type { TypeFaqAccordionSkeleton } from "@/lib/contentful/types";
+
+import { JsonLdScript } from "./json-ld";
+import type { PageBuilderArray } from "./pagebuilder";
+import { faqAccordionToJsonLd } from "./sections/faq-accordion-json-ld";
+
+export function PageBuilderJsonLd({
+  pageBuilder,
+}: {
+  pageBuilder: PageBuilderArray | undefined;
+}) {
+  if (!pageBuilder?.length) return null;
+
+  return (
+    <>
+      {pageBuilder.map((block) => {
+        if (
+          !block ||
+          !("sys" in block) ||
+          !("contentType" in block.sys) ||
+          block.sys.contentType.sys.id !== "faqAccordion"
+        ) {
+          return null;
+        }
+
+        const faqBlock = block as Entry<
+          TypeFaqAccordionSkeleton,
+          "WITHOUT_UNRESOLVABLE_LINKS",
+          string
+        >;
+        const data = faqAccordionToJsonLd(faqBlock.fields.faqs);
+        if (!data) return null;
+
+        return (
+          <JsonLdScript
+            key={`faq-json-ld-${block.sys.id}`}
+            data={data}
+            id={`faq-json-ld-${block.sys.id}`}
+          />
+        );
+      })}
+    </>
+  );
+}

--- a/apps/web/src/components/page-builder-json-ld.tsx
+++ b/apps/web/src/components/page-builder-json-ld.tsx
@@ -3,7 +3,7 @@ import type { Entry } from "contentful";
 import type { TypeFaqAccordionSkeleton } from "@/lib/contentful/types";
 
 import { JsonLdScript } from "./json-ld";
-import type { PageBuilderArray } from "./pagebuilder";
+import { isResolvedEntry, type PageBuilderArray } from "./pagebuilder";
 import { faqAccordionToJsonLd } from "./sections/faq-accordion-json-ld";
 
 export function PageBuilderJsonLd({
@@ -17,9 +17,7 @@ export function PageBuilderJsonLd({
     <>
       {pageBuilder.map((block) => {
         if (
-          !block ||
-          !("sys" in block) ||
-          !("contentType" in block.sys) ||
+          !isResolvedEntry(block) ||
           block.sys.contentType.sys.id !== "faqAccordion"
         ) {
           return null;

--- a/apps/web/src/components/pagebuilder.tsx
+++ b/apps/web/src/components/pagebuilder.tsx
@@ -48,7 +48,7 @@ type AnyPageBuilderEntry =
   | Entry<PageBuilderSkeleton, undefined, string>
   | Entry<PageBuilderSkeleton, "WITHOUT_UNRESOLVABLE_LINKS", string>;
 
-function isResolvedEntry(
+export function isResolvedEntry(
   block:
     | UnresolvedLink<"Entry">
     | Entry<PageBuilderSkeleton, undefined, string>

--- a/apps/web/src/components/pagebuilder.tsx
+++ b/apps/web/src/components/pagebuilder.tsx
@@ -20,7 +20,7 @@ type PageBuilderSkeleton =
   | TypeHeroSkeleton;
 
 // Type for the pageBuilder array that can contain resolved entries or unresolved links
-type PageBuilderArray = (
+export type PageBuilderArray = (
   | UnresolvedLink<"Entry">
   | Entry<PageBuilderSkeleton, undefined, string>
   | Entry<PageBuilderSkeleton, "WITHOUT_UNRESOLVABLE_LINKS", string>

--- a/apps/web/src/components/sections/faq-accordion-json-ld.ts
+++ b/apps/web/src/components/sections/faq-accordion-json-ld.ts
@@ -1,0 +1,32 @@
+import type { Answer, FAQPage, Question, WithContext } from "schema-dts";
+
+import type { TypeFaqAccordion } from "@/lib/contentful/types";
+import { richTextToPlainText } from "@/utils";
+
+type FaqList = NonNullable<
+  TypeFaqAccordion<"WITHOUT_UNRESOLVABLE_LINKS">["fields"]
+>["faqs"];
+
+export function faqAccordionToJsonLd(
+  faqs: FaqList,
+): WithContext<FAQPage> | null {
+  const validFaqs = (faqs ?? []).filter((faq): faq is NonNullable<typeof faq> =>
+    Boolean(faq?.fields?.question),
+  );
+  if (!validFaqs.length) return null;
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: validFaqs.map(
+      (faq): Question => ({
+        "@type": "Question",
+        name: faq.fields.question,
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: richTextToPlainText(faq.fields.answer),
+        } as Answer,
+      }),
+    ),
+  };
+}

--- a/apps/web/src/components/sections/faq-accordion-json-ld.ts
+++ b/apps/web/src/components/sections/faq-accordion-json-ld.ts
@@ -1,4 +1,4 @@
-import type { Answer, FAQPage, Question, WithContext } from "schema-dts";
+import type { FAQPage, Question, WithContext } from "schema-dts";
 
 import type { TypeFaqAccordion } from "@/lib/contentful/types";
 import { richTextToPlainText } from "@/utils";
@@ -25,7 +25,7 @@ export function faqAccordionToJsonLd(
         acceptedAnswer: {
           "@type": "Answer",
           text: richTextToPlainText(faq.fields.answer),
-        } as Answer,
+        },
       }),
     ),
   };

--- a/apps/web/src/components/sections/faq-accordion-json-ld.ts
+++ b/apps/web/src/components/sections/faq-accordion-json-ld.ts
@@ -10,8 +10,10 @@ type FaqList = NonNullable<
 export function faqAccordionToJsonLd(
   faqs: FaqList,
 ): WithContext<FAQPage> | null {
-  const validFaqs = (faqs ?? []).filter((faq): faq is NonNullable<typeof faq> =>
-    Boolean(faq?.fields?.question),
+  const validFaqs = (faqs ?? []).filter(
+    (faq): faq is NonNullable<typeof faq> =>
+      Boolean(faq?.fields?.question) &&
+      richTextToPlainText(faq?.fields?.answer).length > 0,
   );
   if (!validFaqs.length) return null;
 

--- a/apps/web/src/components/sections/faq-accordion.tsx
+++ b/apps/web/src/components/sections/faq-accordion.tsx
@@ -3,14 +3,8 @@ import {
   useContentfulInspectorMode,
   useContentfulLiveUpdates,
 } from "@contentful/live-preview/react";
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@workspace/ui/components/accordion";
 import { Badge } from "@workspace/ui/components/badge";
-import { ArrowUpRight } from "lucide-react";
+import { ArrowUpRight, ChevronDown } from "lucide-react";
 import Link from "next/link";
 
 import type { TypeFaqAccordion } from "@/lib/contentful/types";
@@ -46,31 +40,34 @@ export function FaqAccordion(props: FaqAccordionProps) {
           </div>
         </div>
         <div className="mt-[76px] max-w-[700px] mx-auto relative z-10">
-          <Accordion
-            type="single"
-            collapsible
-            className="w-full"
-            defaultValue={faqs?.[0]?.sys.id ?? ""}
-            {...inspectorProps({ fieldId: "faqs" })}
-          >
-            {faqs?.map((faq, index) => (
-              <AccordionItem
-                value={faq?.sys.id ?? `faq-${index}`}
-                key={faq?.sys.id ?? `faq-${index}`}
-                className="my-4 border-none px-4 py-2 text-lg hover:no-underline group bg-white dark:bg-zinc-900 rounded-2xl"
-              >
-                <AccordionTrigger className="h-full">
-                  {faq?.fields?.question}
-                </AccordionTrigger>
-                <AccordionContent className="text-muted-foreground">
-                  <ContentfulRichText
-                    richText={faq?.fields?.answer}
-                    className="text-sm md:text-base"
-                  />
-                </AccordionContent>
-              </AccordionItem>
-            ))}
-          </Accordion>
+          <div className="w-full" {...inspectorProps({ fieldId: "faqs" })}>
+            {faqs?.map((faq, index) => {
+              const itemId = faq?.sys.id ?? `faq-${index}`;
+              return (
+                <details
+                  key={itemId}
+                  name={`faq-${updatedProps.sys.id}`}
+                  open={index === 0}
+                  className="faq-disclosure group my-4 rounded-2xl bg-white dark:bg-zinc-900 px-4 py-2 text-lg"
+                >
+                  <summary className="flex cursor-pointer list-none items-center justify-between gap-4 py-2 outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 [&::-webkit-details-marker]:hidden">
+                    <h3 className="font-medium text-base">
+                      {faq?.fields?.question}
+                    </h3>
+                    <ChevronDown className="pointer-events-none size-5 shrink-0 text-muted-foreground transition-transform duration-200 group-open:rotate-180" />
+                  </summary>
+                  {faq?.fields?.answer ? (
+                    <div className="pb-2 text-muted-foreground">
+                      <ContentfulRichText
+                        richText={faq.fields.answer}
+                        className="text-sm md:text-base"
+                      />
+                    </div>
+                  ) : null}
+                </details>
+              );
+            })}
+          </div>
           {link && (
             <div className="w-full py-6 text-center flex flex-col items-center">
               <p className="mb-1 text-lg text-zinc-700 dark:text-zinc-400">

--- a/apps/web/src/components/sections/faq-accordion.tsx
+++ b/apps/web/src/components/sections/faq-accordion.tsx
@@ -13,6 +13,54 @@ import { ContentfulRichText } from "../contentful-richtext";
 
 export type FaqAccordionProps = TypeFaqAccordion<"WITHOUT_UNRESOLVABLE_LINKS">;
 
+type FaqEntry = NonNullable<
+  NonNullable<FaqAccordionProps["fields"]>["faqs"]
+>[number];
+
+// Each FAQ is its own referenced entry, so it needs its own live-update +
+// inspector wiring (mirrors the FeatureCard pattern).
+function FaqItem({
+  faq,
+  name,
+  open,
+}: {
+  faq: NonNullable<FaqEntry>;
+  name: string;
+  open: boolean;
+}) {
+  const updatedFaq = useContentfulLiveUpdates(faq);
+  const inspectorProps = useContentfulInspectorMode({
+    entryId: updatedFaq?.sys?.id,
+  });
+  const { question, answer } = updatedFaq?.fields ?? {};
+
+  return (
+    <details
+      name={name}
+      open={open}
+      className="faq-disclosure group my-4 rounded-2xl bg-white dark:bg-zinc-900 px-4 py-2 text-lg"
+    >
+      <summary className="flex cursor-pointer list-none items-center justify-between gap-4 py-2 outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 [&::-webkit-details-marker]:hidden">
+        <h3
+          className="font-medium text-base"
+          {...inspectorProps({ fieldId: "question" })}
+        >
+          {question}
+        </h3>
+        <ChevronDown className="pointer-events-none size-5 shrink-0 text-muted-foreground transition-transform duration-200 group-open:rotate-180" />
+      </summary>
+      {answer ? (
+        <div
+          className="pb-2 text-muted-foreground"
+          {...inspectorProps({ fieldId: "answer" })}
+        >
+          <ContentfulRichText richText={answer} className="text-sm md:text-base" />
+        </div>
+      ) : null}
+    </details>
+  );
+}
+
 export function FaqAccordion(props: FaqAccordionProps) {
   const updatedProps = useContentfulLiveUpdates(props);
   const { eyebrow, title, subtitle, faqs, link } = updatedProps.fields ?? {};
@@ -42,29 +90,14 @@ export function FaqAccordion(props: FaqAccordionProps) {
         <div className="mt-[76px] max-w-[700px] mx-auto relative z-10">
           <div className="w-full" {...inspectorProps({ fieldId: "faqs" })}>
             {faqs?.map((faq, index) => {
-              const itemId = faq?.sys.id ?? `faq-${index}`;
+              if (!faq) return null;
               return (
-                <details
-                  key={itemId}
+                <FaqItem
+                  key={faq.sys.id ?? `faq-${index}`}
+                  faq={faq}
                   name={`faq-${updatedProps.sys.id}`}
                   open={index === 0}
-                  className="faq-disclosure group my-4 rounded-2xl bg-white dark:bg-zinc-900 px-4 py-2 text-lg"
-                >
-                  <summary className="flex cursor-pointer list-none items-center justify-between gap-4 py-2 outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 [&::-webkit-details-marker]:hidden">
-                    <h3 className="font-medium text-base">
-                      {faq?.fields?.question}
-                    </h3>
-                    <ChevronDown className="pointer-events-none size-5 shrink-0 text-muted-foreground transition-transform duration-200 group-open:rotate-180" />
-                  </summary>
-                  {faq?.fields?.answer ? (
-                    <div className="pb-2 text-muted-foreground">
-                      <ContentfulRichText
-                        richText={faq.fields.answer}
-                        className="text-sm md:text-base"
-                      />
-                    </div>
-                  ) : null}
-                </details>
+                />
               );
             })}
           </div>

--- a/apps/web/src/utils.ts
+++ b/apps/web/src/utils.ts
@@ -1,3 +1,9 @@
+import type {
+  Block,
+  Document,
+  Inline,
+  Text,
+} from "@contentful/rich-text-types";
 import type { Asset } from "contentful";
 import slugify from "slugify";
 
@@ -40,4 +46,21 @@ export function getImageUrl(
   if (!url) return undefined;
   const { width, height } = details?.image ?? {};
   return { url: `https:${url}?w=${width}&h=${height}`, width, height };
+}
+
+type RichTextNode = Block | Inline | Text;
+
+const isTextNode = (node: RichTextNode): node is Text =>
+  node.nodeType === "text";
+
+// Plain text for JSON-LD (structured data needs plain strings, not HTML/JSX).
+export function richTextToPlainText(
+  richText: Document | null | undefined,
+): string {
+  if (!richText?.content) return "";
+  const walk = (nodes: RichTextNode[]): string =>
+    nodes
+      .map((node) => (isTextNode(node) ? node.value : walk(node.content)))
+      .join(" ");
+  return walk(richText.content).replace(/\s+/g, " ").trim();
 }

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -134,6 +134,28 @@
   font-size: 2rem !important;
 }
 
+/* FAQ disclosure: smooth open/close, instant fallback where unsupported. */
+@media (prefers-reduced-motion: no-preference) {
+  .faq-disclosure {
+    interpolate-size: allow-keywords;
+  }
+
+  .faq-disclosure::details-content {
+    overflow: hidden;
+    block-size: 0;
+    opacity: 0;
+    transition:
+      block-size 0.2s ease,
+      opacity 0.2s ease,
+      content-visibility 0.2s ease allow-discrete;
+  }
+
+  .faq-disclosure[open]::details-content {
+    block-size: auto;
+    opacity: 1;
+  }
+}
+
 /* view transition api */
 .page-transition {
   opacity: 0;


### PR DESCRIPTION
## Problem / Intent

The FAQ block (`faqAccordion`) rendered its questions with the Radix `Accordion` — a JS-driven `<div>`/`<button>` widget that needs hydration to expand — and the site emitted **no `FAQPage` structured data** anywhere, so FAQ pages couldn't earn rich results. On top of that, all JSON-LD was rendered as `{JSON.stringify(data)}` inside a `<script>`, which React HTML-escapes (corrupting `<`/`&` for crawlers) and can't guard against a `</script>` in CMS text. This change (ROB-2102) moves the FAQ to accessible native `<details>/<summary>`, adds set-and-forget `FAQPage` JSON-LD, and hardens the shared JSON-LD serializer.

## Summary

- FAQ questions now render as native `<details>/<summary>` (question wrapped in `<h3>`), so they expand/collapse with **zero JavaScript** and stay in the heading outline. Single-open is preserved natively via the `<details name>` attribute, scoped per block; older browsers degrade to multi-open.
- Smooth open/close is **CSS-only** (`interpolate-size` + `::details-content` transition) scoped to `.faq-disclosure`, disabled under `prefers-reduced-motion`. The existing rounded-card styling, chevron, and live-preview inspector props are preserved.
- **FAQPage JSON-LD** is emitted automatically for any page containing a `faqAccordion` block — a pure serializer builds the schema and a `PageBuilderJsonLd` component renders it alongside `<PageBuilder>`, so it's set-and-forget with a per-block script id (`faq-json-ld-<sys.id>`).
- **JSON-LD hardening (all types):** `serializeJsonLd` escapes `<`, `>`, `&` to `\uXXXX` and injects via `dangerouslySetInnerHTML`, so a `</script>` in any CMS field can't break out of the tag while staying valid JSON for crawlers. This also fixes the prior React-escaping corruption for Article/Organization/WebSite JSON-LD.
- The Radix `Accordion` primitive is untouched (still used by the mobile navbar) — only the FAQ's usage was converted.

## Core file changes

| File | Change |
| --- | --- |
| `apps/web/src/components/sections/faq-accordion.tsx` | Radix `Accordion*` replaced with native `<details>/<summary>`; `<h3>` question + `ChevronDown` (`group-open:rotate-180`); `name` for single-open, first item `open`. |
| `apps/web/src/components/sections/faq-accordion-json-ld.ts` | **New** pure serializer `faqAccordionToJsonLd(faqs)` returning `WithContext<FAQPage>` or `null` (no JSX). |
| `apps/web/src/components/json-ld.tsx` | Adds `serializeJsonLd` (escapes `<`,`>`,`&`); `JsonLdScript` now injects via `dangerouslySetInnerHTML` — applies to all JSON-LD. |
| `apps/web/src/components/page-builder-json-ld.tsx` | **New** `PageBuilderJsonLd` — maps the pageBuilder and renders `JsonLdScript` for each `faqAccordion` block. |
| `apps/web/src/app/page.tsx`, `apps/web/src/app/[...slug]/page.tsx` | Render `<PageBuilderJsonLd>` alongside `<PageBuilder>` (server side). |
| `apps/web/src/utils.ts` | Adds `richTextToPlainText` — flattens a Contentful rich-text document to plain text for the JSON-LD answer. |
| `apps/web/src/components/pagebuilder.tsx` | Exports the `PageBuilderArray` type for reuse by the wiring component. |
| `packages/ui/src/styles/globals.css` | Adds `.faq-disclosure` disclosure animation (reduced-motion aware). |


## Verification

- [x] `pnpm --filter web check-types`
- [x] `pnpm --filter web lint` (0 errors)
- [x] Home page emits exactly one `<script type="application/ld+json" id="faq-json-ld-…">`, parses as valid `FAQPage` with 3 `Question`/`Answer` pairs, answers are plain text (no tags).
- [x] FAQ renders as native `<details>` (0 Radix accordion markup); opening a 2nd/3rd item auto-closes the others (`[false,false,true]`).
- [x] An FAQ answer containing the literal text `</script>` does not break out of the JSON-LD tag (verified against `serializeJsonLd`: escapes to `</script>`, no literal `<`/`>`/`&`, still valid JSON).
- [ ] Paste a deployed page with an FAQ into Google Rich Results test → FAQPage valid (needs a public URL; schema structure already validated locally).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JSON-LD structured data rendering for the main page content (including home and builder pages) to improve search visibility.
  * Updated the FAQ section to native disclosure UI with improved expand/collapse behavior.
* **Bug Fixes**
  * Hardened JSON-LD script rendering by safely serializing embedded structured data.
  * Improved rich-text FAQ answer rendering by extracting clean plain text for structured output.
* **Style**
  * Enhanced FAQ disclosure animations for non-reduced-motion preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->