### PR TITLE
Content negotiation markdown output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ Callers wrap query promises in `safeAsync` (`apps/web/src/safe-async.ts:5`) whic
 2. Looks up `block.sys.contentType.sys.id` in `BLOCK_COMPONENTS` (currently: `callToAction`, `faqAccordion`, `hero`, `featureCards`)
 3. Renders the matched section component, or `ErrorBlock` if unknown
 
-**To add a new page builder block:** create the Contentful content type, run `typegen`, add the section component under `apps/web/src/components/sections/`, then register it in both `BLOCK_COMPONENTS` and the switch in `PageBuilder`. Also extend the `PageBuilderSkeleton` union.
+**To add a new page builder block:** create the Contentful content type, run `typegen`, add the section component under `apps/web/src/components/sections/`, then register it in both `BLOCK_COMPONENTS` and the switch in `PageBuilder`. Also extend the `PageBuilderSkeleton` union. **Also add a serializer** for the block in `apps/web/src/lib/contentful/page-builder-to-markdown.ts` (see "Markdown content negotiation" below) — otherwise the block is silently dropped from Markdown output.
 
 ### Contentful Live Preview (CRITICAL — read before adding sections)
 
@@ -88,6 +88,16 @@ The root layout (`apps/web/src/app/layout.tsx:44`) reads `draftMode()` and toggl
 - `disable-draft/route.ts` — disables draft, 1s sleep for state sync, redirects.
 - `revalidate/route.ts` — POST webhook from Contentful. Auth via `x-vercel-revalidation-key` header against `CONTENTFUL_REVALIDATION_SECRET`. Body accepts `{ path }` → `revalidatePath` and/or `{ tag }` → `revalidateTag`.
 - `og/route.tsx` — dynamic OG image generation referenced by `getSEOMetadata`.
+
+### Markdown content negotiation (LLM/agent output)
+
+Any page is available as clean Markdown via two surfaces: append **`.md`** to the URL (`/about.md`, `/blog/post.md`, `/index.md`) **or** send **`Accept: text/markdown`** (q-value aware — `;q=0` returns HTML). Plain requests are untouched.
+
+Markdown is built by **serializing the structured Contentful data, never by stripping rendered React** — so page-builder blocks degrade to semantic Markdown (`## question` + answer) and a component can never leak as a tag. Flow:
+- `apps/web/src/proxy.ts` (Next 16 proxy) detects `.md`/`Accept` and rewrites to `api/markdown/route.ts`, forwarding the content path via the `x-markdown-path` header.
+- `api/markdown/route.ts` maps the path → home / page / blog post / blog index, returns `text/markdown` (`200`) with `Vary: Accept`, `Content-Location`, `X-Robots-Tag: noindex, nofollow`; missing doc → `404`, upstream fetch failure → `503`. Always serves published content.
+- `lib/markdown.ts` assembles the document (header + cover + rich text + blocks); `lib/contentful/rich-text-to-markdown.ts` walks the rich-text `Document`; `lib/contentful/page-builder-to-markdown.ts` is the block registry keyed by `contentType.sys.id` — **unknown types serialize to `""`** (fail-safe). The route is an optional catch-all `api/markdown/[[...path]]/route.ts`, so the content path also works as a clean direct URL (`/api/markdown/blog/post`).
+- **Discoverability:** `getSEOMetadata` (`lib/seo.ts`) emits a per-page `<link rel="alternate" type="text/markdown">` pointing at the `.md` twin; `app/llms.txt/route.ts` carries a "For AI agents" negotiation guide + a page/blog index; `app/llms-full.txt/route.ts` serializes the **entire site** into one Markdown document (RAG dump). Both `llms.txt` and `llms-full.txt` are excluded from the proxy matcher.
 
 ### SEO
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ The root layout (`apps/web/src/app/layout.tsx:44`) reads `draftMode()` and toggl
 
 ### Markdown content negotiation (LLM/agent output)
 
-Any page is available as clean Markdown via two surfaces: append **`.md`** to the URL (`/about.md`, `/blog/post.md`, `/index.md`) **or** send **`Accept: text/markdown`** (q-value aware — `;q=0` returns HTML). Plain requests are untouched.
+Any page is available as clean Markdown via two surfaces: append **`.md`** to the URL (`/about.md`, `/blog/post.md`, `/index.md`) **or** send **`Accept: text/markdown`** — `lib/markdown-path.ts` also treats **`Accept: text/plain`** as a Markdown signal (agents like Claude Code send it; browsers never do). Negotiation is q-value aware (`;q=0` returns HTML). Plain requests are untouched.
 
 Markdown is built by **serializing the structured Contentful data, never by stripping rendered React** — so page-builder blocks degrade to semantic Markdown (`## question` + answer) and a component can never leak as a tag. Flow:
 - `apps/web/src/proxy.ts` (Next 16 proxy) detects `.md`/`Accept` and rewrites to `api/markdown/route.ts`, forwarding the content path via the `x-markdown-path` header.

--- a/apps/web/src/app/api/markdown/[[...path]]/route.ts
+++ b/apps/web/src/app/api/markdown/[[...path]]/route.ts
@@ -54,7 +54,8 @@ export async function GET(
     });
   }
 
-  if (markdown) {
+  // Only a null document is "not found"; an empty string is a real (if empty) page.
+  if (markdown !== null) {
     return new Response(markdown, {
       status: 200,
       headers: {

--- a/apps/web/src/app/api/markdown/[[...path]]/route.ts
+++ b/apps/web/src/app/api/markdown/[[...path]]/route.ts
@@ -80,3 +80,7 @@ export async function GET(
     },
   });
 }
+
+// HEAD reuses GET so proxied HEAD requests get identical headers/status
+// (explicit rather than relying on Next's implicit GET→HEAD fallback).
+export { GET as HEAD };

--- a/apps/web/src/app/api/markdown/[[...path]]/route.ts
+++ b/apps/web/src/app/api/markdown/[[...path]]/route.ts
@@ -1,0 +1,81 @@
+import {
+  blogIndexToMarkdown,
+  blogPostToMarkdown,
+  getAllBlogs,
+  getBlogBySlug,
+  getPageBySlugForMarkdown,
+  pageToMarkdown,
+} from "@/lib/markdown";
+import { normalizeMarkdownPath } from "@/lib/markdown-path";
+
+async function buildMarkdown(path: string): Promise<string | null> {
+  const segments = path.split("/").filter(Boolean);
+
+  if (segments.length === 0) {
+    const home = await getPageBySlugForMarkdown("/");
+    return home ? pageToMarkdown(home) : null;
+  }
+
+  if (segments[0] === "blog") {
+    if (segments.length === 1) {
+      const { featured, blogs } = await getAllBlogs(false);
+      return blogIndexToMarkdown(featured, blogs);
+    }
+    const blog = await getBlogBySlug(segments.slice(1).join("/"), false);
+    return blog ? blogPostToMarkdown(blog) : null;
+  }
+
+  const page = await getPageBySlugForMarkdown(path);
+  return page ? pageToMarkdown(page) : null;
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ path?: string[] }> },
+): Promise<Response> {
+  // The content path lives in the URL (`/api/markdown/blog/post`) — the proxy
+  // rewrites `.md`/`Accept` requests here, and it also works directly.
+  const { path: segments = [] } = await params;
+  const path = normalizeMarkdownPath(`/${segments.join("/")}`);
+
+  let markdown: string | null;
+  try {
+    markdown = await buildMarkdown(path);
+  } catch (error) {
+    // A fetch failure must not look like a missing page (404 reads as "gone").
+    console.error("Markdown build failed", error);
+    return new Response("Upstream content fetch failed\n", {
+      status: 503,
+      headers: {
+        "content-type": "text/plain; charset=utf-8",
+        vary: "Accept",
+        "x-content-type-options": "nosniff",
+      },
+    });
+  }
+
+  if (markdown) {
+    return new Response(markdown, {
+      status: 200,
+      headers: {
+        "content-type": "text/markdown; charset=utf-8",
+        // Same URL serves HTML or Markdown by Accept; canonical HTML page is
+        // Content-Location, and the Markdown twin is kept out of search.
+        vary: "Accept",
+        "content-location": path,
+        "x-robots-tag": "noindex, nofollow",
+        "x-content-type-options": "nosniff",
+        "cache-control": "public, s-maxage=60, stale-while-revalidate=300",
+      },
+    });
+  }
+
+  return new Response(`Not found: ${path}\n`, {
+    status: 404,
+    headers: {
+      "content-type": "text/plain; charset=utf-8",
+      vary: "Accept",
+      "x-content-type-options": "nosniff",
+    },
+  });
+}

--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -24,7 +24,8 @@ export async function generateMetadata({
   const metadata = getSEOMetadata({
     title,
     description,
-    slug: blogSlug,
+    // Full path so canonical + Markdown alternate resolve (posts live at /blog/*).
+    slug: blogSlug ? `/blog/${blogSlug.replace(/^\//, "")}` : "/blog",
     contentId: contentId,
     contentType: contentType?.sys?.id,
     ...(seoNoIndex !== undefined && { seoNoIndex }),

--- a/apps/web/src/app/llms-full.txt/route.ts
+++ b/apps/web/src/app/llms-full.txt/route.ts
@@ -11,6 +11,9 @@ const HEADERS = {
   "cache-control": "public, s-maxage=3600, stale-while-revalidate=86400",
 } as const;
 
+// Re-run the Contentful fetches at most hourly (matches the Cache-Control TTL).
+export const revalidate = 3600;
+
 export async function GET(): Promise<Response> {
   const [settings, pages, blogs] = await Promise.allSettled([
     getGlobalSettings(),
@@ -18,11 +21,22 @@ export async function GET(): Promise<Response> {
     getAllBlogs(),
   ]);
 
+  if (settings.status === "rejected") {
+    console.error("llms-full.txt: settings fetch failed", settings.reason);
+  }
   if (pages.status === "rejected") {
     console.error("llms-full.txt: pages fetch failed", pages.reason);
   }
   if (blogs.status === "rejected") {
     console.error("llms-full.txt: blog fetch failed", blogs.reason);
+  }
+
+  // Both content sources failing is a transient upstream error, not empty content.
+  if (pages.status === "rejected" && blogs.status === "rejected") {
+    return new Response("Upstream content fetch failed\n", {
+      status: 503,
+      headers: { "content-type": "text/plain; charset=utf-8" },
+    });
   }
 
   const siteTitle =

--- a/apps/web/src/app/llms-full.txt/route.ts
+++ b/apps/web/src/app/llms-full.txt/route.ts
@@ -1,0 +1,62 @@
+import { getGlobalSettings } from "@/lib/contentful/query";
+import {
+  blogPostToMarkdown,
+  getAllBlogs,
+  getAllPagesForMarkdown,
+  pageToMarkdown,
+} from "@/lib/markdown";
+
+const HEADERS = {
+  "content-type": "text/plain; charset=utf-8",
+  "cache-control": "public, s-maxage=3600, stale-while-revalidate=86400",
+} as const;
+
+export async function GET(): Promise<Response> {
+  const [settings, pages, blogs] = await Promise.allSettled([
+    getGlobalSettings(),
+    getAllPagesForMarkdown(),
+    getAllBlogs(),
+  ]);
+
+  if (pages.status === "rejected") {
+    console.error("llms-full.txt: pages fetch failed", pages.reason);
+  }
+  if (blogs.status === "rejected") {
+    console.error("llms-full.txt: blog fetch failed", blogs.reason);
+  }
+
+  const siteTitle =
+    (settings.status === "fulfilled" && settings.value?.fields?.siteTitle) ||
+    "Site";
+
+  // Home (slug "/") first, then the rest of the pages.
+  const pageDocs =
+    pages.status === "fulfilled"
+      ? [...pages.value].sort((a, b) => {
+          if (a.fields.slug === "/") return -1;
+          if (b.fields.slug === "/") return 1;
+          return 0;
+        })
+      : [];
+  const blogDocs =
+    blogs.status === "fulfilled"
+      ? [blogs.value.featured, ...blogs.value.blogs].filter(
+          (blog): blog is NonNullable<typeof blog> => Boolean(blog),
+        )
+      : [];
+
+  const sections = [
+    ...pageDocs.map((page) => pageToMarkdown(page)),
+    ...blogDocs.map((blog) => blogPostToMarkdown(blog)),
+  ].filter((section) => section.trim());
+
+  const header = [
+    `# ${siteTitle} - Complete Content`,
+    "",
+    `> This file contains all content from ${siteTitle} in Markdown format.`,
+    "> Optimized for LLM consumption and RAG systems.",
+  ].join("\n");
+
+  const body = [header, ...sections].join("\n\n---\n\n");
+  return new Response(`${body}\n`, { headers: HEADERS });
+}

--- a/apps/web/src/app/llms.txt/route.ts
+++ b/apps/web/src/app/llms.txt/route.ts
@@ -1,0 +1,97 @@
+import {
+  getAllBlogs,
+  getAllPageSlugs,
+  getGlobalSettings,
+} from "@/lib/contentful/query";
+
+const HEADERS = {
+  "content-type": "text/plain; charset=utf-8",
+  "cache-control": "public, s-maxage=3600, stale-while-revalidate=86400",
+} as const;
+
+function slugToTitle(slug: string): string {
+  return (
+    slug
+      .replace(/^\//, "")
+      .split("/")
+      .filter(Boolean)
+      .map((segment) =>
+        segment
+          .split("-")
+          .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+          .join(" "),
+      )
+      .join(" / ") || "Home"
+  );
+}
+
+export async function GET(): Promise<Response> {
+  const [settings, slugs, blogs] = await Promise.allSettled([
+    getGlobalSettings(),
+    getAllPageSlugs(),
+    getAllBlogs(),
+  ]);
+
+  if (settings.status === "rejected") {
+    console.error("llms.txt: settings fetch failed", settings.reason);
+  }
+  if (slugs.status === "rejected") {
+    console.error("llms.txt: page slugs fetch failed", slugs.reason);
+  }
+  if (blogs.status === "rejected") {
+    console.error("llms.txt: blog fetch failed", blogs.reason);
+  }
+
+  const siteTitle =
+    (settings.status === "fulfilled" && settings.value?.fields?.siteTitle) ||
+    "Site";
+  const siteDescription =
+    (settings.status === "fulfilled" &&
+      settings.value?.fields?.siteDescription) ||
+    "";
+  const pageSlugs = slugs.status === "fulfilled" ? slugs.value : [];
+  const posts =
+    blogs.status === "fulfilled"
+      ? [blogs.value.featured, ...blogs.value.blogs]
+      : [];
+
+  const pageLines = [
+    "- [Home](/index.md)",
+    ...pageSlugs
+      .filter((slug): slug is string => Boolean(slug))
+      .map((slug) => {
+        const path = slug.startsWith("/") ? slug : `/${slug}`;
+        return `- [${slugToTitle(path)}](${path}.md)`;
+      }),
+  ];
+
+  const blogLines = posts.flatMap((post) => {
+    const slug = post?.fields?.slug?.trim();
+    if (!slug) {
+      return [];
+    }
+    const clean = slug.replace(/^\//, "");
+    const title = post?.fields?.title ?? slugToTitle(clean);
+    return [`- [${title}](/blog/${clean}.md)`];
+  });
+
+  const body = [
+    `# ${siteTitle}`,
+    ...(siteDescription ? [`> ${siteDescription}`] : []),
+    "",
+    "## For AI agents",
+    "",
+    "Every page is available as clean Markdown. Append `.md` to any URL (e.g.",
+    "`/about.md`) or send `Accept: text/markdown` against the canonical URL.",
+    "Page-builder blocks are serialized to semantic Markdown, so no component",
+    "markup leaks. For the entire site as one document, fetch `/llms-full.txt`.",
+    "",
+    "## Pages",
+    ...pageLines,
+    "",
+    "## Blog",
+    ...blogLines,
+  ].join("\n");
+
+  return new Response(`${body}\n`, { headers: HEADERS });
+}

--- a/apps/web/src/app/llms.txt/route.ts
+++ b/apps/web/src/app/llms.txt/route.ts
@@ -9,6 +9,9 @@ const HEADERS = {
   "cache-control": "public, s-maxage=3600, stale-while-revalidate=86400",
 } as const;
 
+// Re-run the Contentful fetches at most hourly (matches the Cache-Control TTL).
+export const revalidate = 3600;
+
 function slugToTitle(slug: string): string {
   return (
     slug

--- a/apps/web/src/app/llms.txt/route.ts
+++ b/apps/web/src/app/llms.txt/route.ts
@@ -42,6 +42,14 @@ export async function GET(): Promise<Response> {
     console.error("llms.txt: blog fetch failed", blogs.reason);
   }
 
+  // Both content sources failing is a transient upstream error, not an empty site.
+  if (slugs.status === "rejected" && blogs.status === "rejected") {
+    return new Response("Upstream content fetch failed\n", {
+      status: 503,
+      headers: { "content-type": "text/plain; charset=utf-8" },
+    });
+  }
+
   const siteTitle =
     (settings.status === "fulfilled" && settings.value?.fields?.siteTitle) ||
     "Site";

--- a/apps/web/src/lib/contentful/page-builder-to-markdown.ts
+++ b/apps/web/src/lib/contentful/page-builder-to-markdown.ts
@@ -145,9 +145,10 @@ function featureCardsToMarkdown(
         return "";
       }
       // Icon is intentionally dropped from Markdown.
-      const title = cf.cardLink
-        ? `### ${mdLink(cf.title ?? "", cf.cardLink)}`
-        : heading(cf.title, 3);
+      const title =
+        cf.cardLink && cf.title?.trim()
+          ? `### ${mdLink(cf.title, cf.cardLink)}`
+          : heading(cf.title, 3);
       return joinSections([title, richTextToMarkdown(cf.richText)]);
     })
     .filter((card) => card.trim())

--- a/apps/web/src/lib/contentful/page-builder-to-markdown.ts
+++ b/apps/web/src/lib/contentful/page-builder-to-markdown.ts
@@ -1,0 +1,211 @@
+/**
+ * Serializes a `pageBuilder` array to semantic Markdown by dispatching each
+ * block on its `contentType.sys.id` — mirroring `BLOCK_COMPONENTS` in
+ * `components/pagebuilder.tsx`, but emitting headings + text instead of React.
+ *
+ * The registry is the fail-safe: an **unknown block type serializes to `""`**,
+ * so a component can never leak into Markdown as a raw tag. When you add a new
+ * page-builder block, add its serializer here too (see CLAUDE.md).
+ */
+
+import type {
+  TypeButton,
+  TypeCallToAction,
+  TypeFaqAccordion,
+  TypeFeatureCards,
+  TypeHero,
+} from "@/lib/contentful/types";
+import { getButtonUrl } from "@/lib/contentful-utils";
+
+import {
+  assetToMarkdown,
+  escapeMarkdown,
+  formatUrl,
+  type MarkdownAsset,
+  richTextToMarkdown,
+} from "./rich-text-to-markdown";
+
+type Links = "WITHOUT_UNRESOLVABLE_LINKS";
+
+interface ResolvedBlock {
+  sys?: { type?: string; contentType?: { sys?: { id?: string } } };
+  fields?: Record<string, unknown>;
+}
+
+export type MarkdownPageBuilder =
+  | ReadonlyArray<ResolvedBlock | undefined>
+  | null
+  | undefined;
+
+function joinSections(sections: Array<string | null | undefined>): string {
+  return sections.filter((section) => section?.trim()).join("\n\n");
+}
+
+function heading(title: string | undefined | null, level: 1 | 2 | 3): string {
+  const text = title?.trim();
+  return text ? `${"#".repeat(level)} ${escapeMarkdown(text)}` : "";
+}
+
+function eyebrow(text: string | undefined | null): string {
+  const value = text?.trim();
+  return value ? `**${escapeMarkdown(value)}**` : "";
+}
+
+function paragraph(text: string | undefined | null): string {
+  const value = text?.trim();
+  return value ? escapeMarkdown(value) : "";
+}
+
+function mdLink(label: string, href: string | null | undefined): string {
+  const text = label.trim();
+  if (!text) {
+    return "";
+  }
+  return href
+    ? `[${escapeMarkdown(text)}](${formatUrl(href)})`
+    : escapeMarkdown(text);
+}
+
+function buttonsToMarkdown(
+  buttons: ReadonlyArray<TypeButton<Links, string> | undefined> | undefined,
+): string {
+  if (!buttons?.length) {
+    return "";
+  }
+  return buttons
+    .map((button) => {
+      if (!button?.fields) {
+        return null;
+      }
+      const label = button.fields.label?.trim();
+      if (!label) {
+        return null;
+      }
+      return `- ${mdLink(label, getButtonUrl(button))}`;
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function heroToMarkdown(block: TypeHero<Links, string>): string {
+  const f = block.fields;
+  if (!f) {
+    return "";
+  }
+  return joinSections([
+    eyebrow(f.badge),
+    heading(f.title, 1),
+    richTextToMarkdown(f.richText),
+    assetToMarkdown(f.image as MarkdownAsset | undefined),
+    buttonsToMarkdown(f.buttons),
+  ]);
+}
+
+function faqAccordionToMarkdown(
+  block: TypeFaqAccordion<Links, string>,
+): string {
+  const f = block.fields;
+  if (!f) {
+    return "";
+  }
+  const items = (f.faqs ?? [])
+    .map((faq) => {
+      const ff = faq?.fields;
+      if (!ff) {
+        return "";
+      }
+      return joinSections([
+        heading(ff.question, 3),
+        richTextToMarkdown(ff.answer),
+      ]);
+    })
+    .filter((item) => item.trim())
+    .join("\n\n");
+
+  return joinSections([
+    eyebrow(f.eyebrow),
+    heading(f.title, 2),
+    paragraph(f.subtitle),
+    items,
+    f.link ? mdLink("Get in touch with sales", f.link) : "",
+  ]);
+}
+
+function featureCardsToMarkdown(
+  block: TypeFeatureCards<Links, string>,
+): string {
+  const f = block.fields;
+  if (!f) {
+    return "";
+  }
+  const cards = (f.cards ?? [])
+    .map((card) => {
+      const cf = card?.fields;
+      if (!cf) {
+        return "";
+      }
+      // Icon is intentionally dropped from Markdown.
+      const title = cf.cardLink
+        ? `### ${mdLink(cf.title ?? "", cf.cardLink)}`
+        : heading(cf.title, 3);
+      return joinSections([title, richTextToMarkdown(cf.richText)]);
+    })
+    .filter((card) => card.trim())
+    .join("\n\n");
+
+  return joinSections([
+    eyebrow(f.eyebrow),
+    heading(f.title, 2),
+    richTextToMarkdown(f.richText),
+    cards,
+  ]);
+}
+
+function callToActionToMarkdown(
+  block: TypeCallToAction<Links, string>,
+): string {
+  const f = block.fields;
+  if (!f) {
+    return "";
+  }
+  // The newsletter form is interactive → intentionally dropped from Markdown.
+  return joinSections([
+    eyebrow(f.eyebrow),
+    heading(f.title, 2),
+    richTextToMarkdown(f.richText),
+    buttonsToMarkdown(f.buttons),
+    richTextToMarkdown(f.helperText),
+  ]);
+}
+
+const SERIALIZERS: Record<string, (block: never) => string> = {
+  hero: heroToMarkdown as (block: never) => string,
+  faqAccordion: faqAccordionToMarkdown as (block: never) => string,
+  featureCards: featureCardsToMarkdown as (block: never) => string,
+  callToAction: callToActionToMarkdown as (block: never) => string,
+};
+
+function resolvedTypeId(block: ResolvedBlock | undefined): string | null {
+  const sys = block?.sys;
+  if (!sys || sys.type === "Link" || !block?.fields) {
+    return null;
+  }
+  const id = sys.contentType?.sys?.id;
+  return typeof id === "string" ? id : null;
+}
+
+export function pageBuilderToMarkdown(
+  pageBuilder: MarkdownPageBuilder,
+): string {
+  if (!pageBuilder?.length) {
+    return "";
+  }
+  return pageBuilder
+    .map((block) => {
+      const id = resolvedTypeId(block);
+      const serialize = id ? SERIALIZERS[id] : undefined;
+      return serialize ? serialize(block as never) : "";
+    })
+    .filter((section) => section.trim())
+    .join("\n\n");
+}

--- a/apps/web/src/lib/contentful/rich-text-to-markdown.ts
+++ b/apps/web/src/lib/contentful/rich-text-to-markdown.ts
@@ -1,0 +1,237 @@
+/**
+ * Serializes a Contentful rich-text `Document` to semantic Markdown.
+ *
+ * Contentful ships no official rich-text → Markdown renderer, so this is a
+ * hand-written walk of the node tree — the Markdown analogue of
+ * `contentful-richtext.tsx`. Author text is escaped so literal metacharacters
+ * (`user_name`, `foo[bar]`) are not reinterpreted as formatting, and unknown /
+ * embedded blocks degrade to text or `""` rather than leaking markup.
+ */
+
+import type {
+  Block,
+  Document,
+  Inline,
+  Text,
+} from "@contentful/rich-text-types";
+import { BLOCKS, INLINES, MARKS } from "@contentful/rich-text-types";
+
+import { isSafeUri } from "@/lib/uri";
+
+export type RichTextDocument = Document | null | undefined;
+
+/** A resolved Contentful asset as it appears on a rich-text embed / link. */
+export interface MarkdownAsset {
+  fields?: {
+    title?: string;
+    description?: string;
+    file?: {
+      url?: string;
+      contentType?: string;
+      fileName?: string;
+    };
+  };
+}
+
+type RichTextNode = Block | Inline | Text;
+
+/** Escapes Markdown metacharacters (and `<`/`>`) in author-supplied text. */
+export function escapeMarkdown(text: string): string {
+  return text.replace(/([\\`*_{}[\]<>|~])/g, "\\$1");
+}
+
+/** Makes a URL safe as a Markdown link target (parens/spaces break `](url)`). */
+export function formatUrl(url: string): string {
+  return url
+    .trim()
+    .replace(/ /g, "%20")
+    .replace(/\(/g, "%28")
+    .replace(/\)/g, "%29");
+}
+
+/** Resolves a Contentful asset to an absolute URL (protocol-relative → https). */
+export function resolveAssetUrl(asset?: MarkdownAsset | null): string | null {
+  const url = asset?.fields?.file?.url;
+  if (!url) {
+    return null;
+  }
+  return url.startsWith("//") ? `https:${url}` : url;
+}
+
+/** `![alt](url)` for image assets, a `[label](url)` link otherwise, else text. */
+export function assetToMarkdown(asset?: MarkdownAsset | null): string {
+  const url = resolveAssetUrl(asset);
+  const alt = (asset?.fields?.description ?? asset?.fields?.title ?? "").trim();
+  const fileName = asset?.fields?.file?.fileName ?? "";
+  const isImage = asset?.fields?.file?.contentType?.startsWith("image/");
+  if (!url) {
+    return escapeMarkdown(alt);
+  }
+  if (isImage) {
+    return `![${escapeMarkdown(alt)}](${formatUrl(url)})`;
+  }
+  const label = alt || fileName || "Download file";
+  return `[${escapeMarkdown(label)}](${formatUrl(url)})`;
+}
+
+function isText(node: RichTextNode): node is Text {
+  return node.nodeType === "text";
+}
+
+function hasMark(node: Text, type: string): boolean {
+  return node.marks.some((mark) => mark.type === type);
+}
+
+function renderText(node: Text): string {
+  // Code spans are literal — don't escape inside backticks.
+  let text = hasMark(node, MARKS.CODE)
+    ? `\`${node.value}\``
+    : escapeMarkdown(node.value);
+  if (hasMark(node, MARKS.BOLD)) {
+    text = `**${text}**`;
+  }
+  if (hasMark(node, MARKS.ITALIC)) {
+    text = `_${text}_`;
+  }
+  // Underline has no Markdown equivalent — rendered as plain text.
+  return text;
+}
+
+function renderInlineChildren(node: Block | Inline): string {
+  return node.content.map((child) => renderInline(child)).join("");
+}
+
+function entryHref(target: unknown): string | null {
+  const slug = (target as { fields?: { slug?: string } } | undefined)?.fields
+    ?.slug;
+  if (!slug) {
+    return null;
+  }
+  return slug.startsWith("/") ? slug : `/${slug}`;
+}
+
+function renderInline(node: RichTextNode): string {
+  if (isText(node)) {
+    return renderText(node);
+  }
+
+  switch (node.nodeType) {
+    case INLINES.HYPERLINK: {
+      const uri = node.data?.["uri"] as string | undefined;
+      const label = renderInlineChildren(node);
+      return uri && isSafeUri(uri) ? `[${label}](${formatUrl(uri)})` : label;
+    }
+    case INLINES.ENTRY_HYPERLINK: {
+      const href = entryHref(node.data?.["target"]);
+      const label = renderInlineChildren(node);
+      return href ? `[${label}](${href})` : label;
+    }
+    case INLINES.ASSET_HYPERLINK: {
+      const url = resolveAssetUrl(node.data?.["target"] as MarkdownAsset);
+      const label = renderInlineChildren(node);
+      return url ? `[${label}](${formatUrl(url)})` : label;
+    }
+    case INLINES.EMBEDDED_ENTRY:
+      return "";
+    default:
+      return "content" in node ? renderInlineChildren(node) : "";
+  }
+}
+
+const HEADING_LEVEL: Record<string, number> = {
+  [BLOCKS.HEADING_1]: 1,
+  [BLOCKS.HEADING_2]: 2,
+  [BLOCKS.HEADING_3]: 3,
+  [BLOCKS.HEADING_4]: 4,
+  [BLOCKS.HEADING_5]: 5,
+  [BLOCKS.HEADING_6]: 6,
+};
+
+function renderList(node: Block, ordered: boolean, depth: number): string {
+  return node.content
+    .map((item, index) => renderListItem(item as Block, ordered, index, depth))
+    .join("\n");
+}
+
+function renderListItem(
+  item: Block,
+  ordered: boolean,
+  index: number,
+  depth: number,
+): string {
+  const indent = "  ".repeat(depth);
+  const marker = ordered ? `${index + 1}.` : "-";
+  const lines: string[] = [];
+  const nested: string[] = [];
+
+  for (const child of item.content) {
+    if (
+      child.nodeType === BLOCKS.UL_LIST ||
+      child.nodeType === BLOCKS.OL_LIST
+    ) {
+      nested.push(
+        renderList(
+          child as Block,
+          child.nodeType === BLOCKS.OL_LIST,
+          depth + 1,
+        ),
+      );
+    } else {
+      const rendered = renderBlock(child as Block);
+      if (rendered.trim()) {
+        lines.push(rendered);
+      }
+    }
+  }
+
+  let out = `${indent}${marker} ${lines.join(" ").trim()}`.trimEnd();
+  if (nested.length) {
+    out += `\n${nested.join("\n")}`;
+  }
+  return out;
+}
+
+function renderBlock(node: Block): string {
+  const level = HEADING_LEVEL[node.nodeType];
+  if (level) {
+    const text = renderInlineChildren(node).trim();
+    return text ? `${"#".repeat(level)} ${text}` : "";
+  }
+
+  switch (node.nodeType) {
+    case BLOCKS.PARAGRAPH:
+      return renderInlineChildren(node).trim();
+    case BLOCKS.UL_LIST:
+      return renderList(node, false, 0);
+    case BLOCKS.OL_LIST:
+      return renderList(node, true, 0);
+    case BLOCKS.QUOTE: {
+      const inner = node.content
+        .map((child) => renderBlock(child as Block))
+        .filter((block) => block.trim())
+        .join("\n\n");
+      return inner
+        .split("\n")
+        .map((line) => (line ? `> ${line}` : ">"))
+        .join("\n");
+    }
+    case BLOCKS.HR:
+      return "---";
+    case BLOCKS.EMBEDDED_ASSET:
+      return assetToMarkdown(node.data?.["target"] as MarkdownAsset);
+    // Unknown / embedded entry blocks serialize to "" — never leak as markup.
+    default:
+      return "";
+  }
+}
+
+/** Walks a Contentful rich-text `Document` and returns semantic Markdown. */
+export function richTextToMarkdown(doc: RichTextDocument): string {
+  if (!doc?.content) {
+    return "";
+  }
+  return doc.content
+    .map((node) => renderBlock(node as Block))
+    .filter((block) => block.trim())
+    .join("\n\n");
+}

--- a/apps/web/src/lib/contentful/rich-text-to-markdown.ts
+++ b/apps/web/src/lib/contentful/rich-text-to-markdown.ts
@@ -82,10 +82,21 @@ function hasMark(node: Text, type: string): boolean {
   return node.marks.some((mark) => mark.type === type);
 }
 
+/** Wraps a code span in a backtick fence longer than any run inside it. */
+function codeSpan(value: string): string {
+  const runs = value.match(/`+/g);
+  const fence = "`".repeat(
+    (runs ? Math.max(...runs.map((r) => r.length)) : 0) + 1,
+  );
+  // Pad when the value starts/ends with a backtick so the fence stays distinct.
+  const pad = value.startsWith("`") || value.endsWith("`") ? " " : "";
+  return `${fence}${pad}${value}${pad}${fence}`;
+}
+
 function renderText(node: Text): string {
   // Code spans are literal — don't escape inside backticks.
   let text = hasMark(node, MARKS.CODE)
-    ? `\`${node.value}\``
+    ? codeSpan(node.value)
     : escapeMarkdown(node.value);
   if (hasMark(node, MARKS.BOLD)) {
     text = `**${text}**`;

--- a/apps/web/src/lib/markdown-path.ts
+++ b/apps/web/src/lib/markdown-path.ts
@@ -1,0 +1,63 @@
+/**
+ * Pure path/negotiation helpers shared by the Markdown proxy and route.
+ * Kept free of heavy imports so the proxy bundle stays light.
+ */
+
+export const MARKDOWN_MEDIA_TYPE = "text/markdown";
+
+// `text/plain` is treated as a Markdown signal too: agents (e.g. Claude Code)
+// request it, while browsers never send it — they lead with `text/html` and use
+// `*/*` as the wildcard — so this can't accidentally serve Markdown to a browser.
+const MARKDOWN_MEDIA_TYPES = new Set([MARKDOWN_MEDIA_TYPE, "text/plain"]);
+
+/** Canonicalizes a path: strips `.md` and trailing slash, maps `/index` → `/`. */
+export function normalizeMarkdownPath(raw: string): string {
+  const trimmed = raw.trim();
+  const slashed = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  const withoutMd = slashed.endsWith(".md") ? slashed.slice(0, -3) : slashed;
+  const withoutTrailing =
+    withoutMd.length > 1 && withoutMd.endsWith("/")
+      ? withoutMd.slice(0, -1)
+      : withoutMd;
+  return withoutTrailing === "/index" ? "/" : withoutTrailing;
+}
+
+/**
+ * Parses an `Accept` header into `{ type, q }` entries (type + `q` matched
+ * case-insensitively; entries with `q` outside [0, 1] dropped, e.g. `q=2`).
+ */
+function parseAccept(accept: string): Array<{ type: string; q: number }> {
+  const entries: Array<{ type: string; q: number }> = [];
+  for (const part of accept.split(",")) {
+    const [media, ...params] = part
+      .trim()
+      .split(";")
+      .map((p) => p.trim());
+    if (!media) {
+      continue;
+    }
+    const qParam = params.find((p) => p.toLowerCase().startsWith("q="));
+    const q = qParam ? Number.parseFloat(qParam.slice(2)) : 1;
+    if (!Number.isFinite(q) || q < 0 || q > 1) {
+      continue;
+    }
+    entries.push({ type: media.toLowerCase(), q });
+  }
+  return entries;
+}
+
+/**
+ * True when a Markdown type (`text/markdown` or `text/plain`) is preferred
+ * (q > 0 and >= every other type's q). So a Markdown type wins; `;q=0` and
+ * HTML-preferred lists do not.
+ */
+export function prefersMarkdown(accept: string): boolean {
+  const entries = parseAccept(accept);
+  const markdownQ = entries
+    .filter(({ type }) => MARKDOWN_MEDIA_TYPES.has(type))
+    .reduce((max, { q }) => Math.max(max, q), 0);
+  const otherQ = entries
+    .filter(({ type }) => !MARKDOWN_MEDIA_TYPES.has(type))
+    .reduce((max, { q }) => Math.max(max, q), 0);
+  return markdownQ > 0 && markdownQ >= otherQ;
+}

--- a/apps/web/src/lib/markdown.ts
+++ b/apps/web/src/lib/markdown.ts
@@ -1,0 +1,115 @@
+/**
+ * Document-level Markdown assembly for the content-negotiation surface.
+ *
+ * Fetches are done with `getClient(false)` (always published) and return `null`
+ * for a genuinely missing document while letting real upstream errors throw —
+ * so the route can distinguish `404` (missing) from `503` (fetch failure).
+ * `getBlogBySlug` already has that shape, so it is reused directly.
+ */
+
+import { getClient } from "./contentful/client";
+import {
+  type MarkdownPageBuilder,
+  pageBuilderToMarkdown,
+} from "./contentful/page-builder-to-markdown";
+import { getAllBlogs, getBlogBySlug } from "./contentful/query";
+import {
+  assetToMarkdown,
+  escapeMarkdown,
+  type MarkdownAsset,
+  richTextToMarkdown,
+} from "./contentful/rich-text-to-markdown";
+import type { TypeBlog, TypePage, TypePageSkeleton } from "./contentful/types";
+
+type Links = "WITHOUT_UNRESOLVABLE_LINKS";
+type PageDoc = TypePage<Links, string>;
+type BlogDoc = TypeBlog<Links, string>;
+
+/** Fetches a page by slug, returning `null` when none exists (errors throw). */
+export async function getPageBySlugForMarkdown(
+  slug: string,
+): Promise<PageDoc | null> {
+  const res = await getClient(false).getEntries<TypePageSkeleton>({
+    content_type: "page",
+    "fields.slug": slug,
+    include: 10,
+    limit: 1,
+  });
+  return res.items[0] ?? null;
+}
+
+/** Fetches every page with full fields — used to assemble `llms-full.txt`. */
+export async function getAllPagesForMarkdown(): Promise<PageDoc[]> {
+  const res = await getClient(false).getEntries<TypePageSkeleton>({
+    content_type: "page",
+    include: 10,
+  });
+  return res.items;
+}
+
+export { getAllBlogs, getBlogBySlug };
+
+function joinSections(sections: Array<string | null | undefined>): string {
+  return sections.filter((section) => section?.trim()).join("\n\n");
+}
+
+function withTrailingNewline(
+  sections: Array<string | null | undefined>,
+): string {
+  const body = joinSections(sections);
+  return body ? `${body}\n` : "";
+}
+
+function documentHeader(
+  title?: string | null,
+  description?: string | null,
+): string {
+  const t = title?.trim();
+  const d = description?.trim();
+  return joinSections([
+    t ? `# ${escapeMarkdown(t)}` : "",
+    d ? escapeMarkdown(d) : "",
+  ]);
+}
+
+export function pageToMarkdown(page: PageDoc): string {
+  const f = page.fields;
+  return withTrailingNewline([
+    documentHeader(f?.title, f?.description),
+    pageBuilderToMarkdown(f?.pageBuilder as MarkdownPageBuilder),
+  ]);
+}
+
+export function blogPostToMarkdown(blog: BlogDoc): string {
+  const f = blog.fields;
+  return withTrailingNewline([
+    documentHeader(f?.title, f?.description),
+    assetToMarkdown(f?.image as MarkdownAsset | undefined),
+    richTextToMarkdown(f?.richText),
+    pageBuilderToMarkdown(f?.pageBuilder as MarkdownPageBuilder),
+  ]);
+}
+
+export function blogIndexToMarkdown(
+  featured: BlogDoc | undefined,
+  blogs: BlogDoc[],
+): string {
+  // Featured first, then the (already `-publishedDate`-ordered) list — matching
+  // the HTML index.
+  const list = [featured, ...blogs]
+    .map((post) => {
+      const title = post?.fields?.title?.trim();
+      const slug = post?.fields?.slug?.trim();
+      if (!title || !slug) {
+        return null;
+      }
+      return `- [${escapeMarkdown(title)}](/blog/${slug.replace(/^\//, "")})`;
+    })
+    .filter(Boolean)
+    .join("\n");
+
+  return withTrailingNewline([
+    "# Blog",
+    list ? `## Latest posts\n\n${list}` : "",
+  ]);
+}

--- a/apps/web/src/lib/markdown.ts
+++ b/apps/web/src/lib/markdown.ts
@@ -40,11 +40,25 @@ export async function getPageBySlugForMarkdown(
 
 /** Fetches every page with full fields — used to assemble `llms-full.txt`. */
 export async function getAllPagesForMarkdown(): Promise<PageDoc[]> {
-  const res = await getClient(false).getEntries<TypePageSkeleton>({
-    content_type: "page",
-    include: 10,
-  });
-  return res.items;
+  const client = getClient(false);
+  const all: PageDoc[] = [];
+  const limit = 100;
+  let skip = 0;
+  let total = Infinity;
+  // Paginate so pages beyond the first batch aren't dropped.
+  while (skip < total) {
+    const res = await client.getEntries<TypePageSkeleton>({
+      content_type: "page",
+      include: 10,
+      limit,
+      skip,
+    });
+    all.push(...res.items);
+    total = res.total;
+    if (res.items.length === 0) break;
+    skip += res.items.length;
+  }
+  return all;
 }
 
 export { getAllBlogs, getBlogBySlug };

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -50,6 +50,11 @@ function generateOgImageUrl(params: OgImageParams = {}): string {
   return `${baseUrl}/api/og?${searchParams.toString()}`;
 }
 
+/** Ensures a slug has a single leading slash. */
+function normalizeSlug(slug: string): string {
+  return slug.startsWith("/") ? slug : `/${slug}`;
+}
+
 function buildPageUrl({
   baseUrl,
   slug,
@@ -57,8 +62,7 @@ function buildPageUrl({
   baseUrl: string;
   slug: string;
 }): string {
-  const normalizedSlug = slug.startsWith("/") ? slug : `/${slug}`;
-  return `${baseUrl}${normalizedSlug}`;
+  return `${baseUrl}${normalizeSlug(slug)}`;
 }
 
 function extractTitle({
@@ -90,8 +94,7 @@ export function getSEOMetadata(page: PageSeoData = {}): Metadata {
   const baseUrl = getBaseUrl();
   const pageUrl = buildPageUrl({ baseUrl, slug });
   // Advertise the Markdown twin so agents can discover content negotiation.
-  const normalizedSlug = slug.startsWith("/") ? slug : `/${slug}`;
-  const markdownUrl = `${baseUrl}${slug === "/" ? "/index.md" : `${normalizedSlug}.md`}`;
+  const markdownUrl = `${baseUrl}${slug === "/" ? "/index.md" : `${normalizeSlug(slug)}.md`}`;
 
   // Build default metadata values
   const defaultTitle = extractTitle({

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -65,6 +65,17 @@ function buildPageUrl({
   return `${baseUrl}${normalizeSlug(slug)}`;
 }
 
+/** The URL of a page's Markdown twin (`/` → `/index.md`, else `<slug>.md`). */
+function buildMarkdownUrl({
+  baseUrl,
+  slug,
+}: {
+  baseUrl: string;
+  slug: string;
+}): string {
+  return `${baseUrl}${slug === "/" ? "/index.md" : `${normalizeSlug(slug)}.md`}`;
+}
+
 function extractTitle({
   pageTitle,
   slug,
@@ -94,7 +105,7 @@ export function getSEOMetadata(page: PageSeoData = {}): Metadata {
   const baseUrl = getBaseUrl();
   const pageUrl = buildPageUrl({ baseUrl, slug });
   // Advertise the Markdown twin so agents can discover content negotiation.
-  const markdownUrl = `${baseUrl}${slug === "/" ? "/index.md" : `${normalizeSlug(slug)}.md`}`;
+  const markdownUrl = buildMarkdownUrl({ baseUrl, slug });
 
   // Build default metadata values
   const defaultTitle = extractTitle({

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -89,6 +89,9 @@ export function getSEOMetadata(page: PageSeoData = {}): Metadata {
 
   const baseUrl = getBaseUrl();
   const pageUrl = buildPageUrl({ baseUrl, slug });
+  // Advertise the Markdown twin so agents can discover content negotiation.
+  const normalizedSlug = slug.startsWith("/") ? slug : `/${slug}`;
+  const markdownUrl = `${baseUrl}${slug === "/" ? "/index.md" : `${normalizedSlug}.md`}`;
 
   // Build default metadata values
   const defaultTitle = extractTitle({
@@ -130,6 +133,7 @@ export function getSEOMetadata(page: PageSeoData = {}): Metadata {
     },
     alternates: {
       canonical: pageUrl,
+      types: { "text/markdown": markdownUrl },
     },
     openGraph: {
       type: "website",

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,0 +1,49 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+import { normalizeMarkdownPath, prefersMarkdown } from "@/lib/markdown-path";
+
+/**
+ * Content negotiation for Markdown: a `.md` URL or `Accept: text/markdown` is
+ * rewritten to the `/api/markdown` route handler; everything else passes through
+ * untouched (the global CSP / `X-Frame-Options` headers in `next.config.ts` are
+ * unaffected). The Markdown route sets `Vary: Accept` so a shared cache never
+ * serves Markdown to a browser; the `.md` suffix is the cache-safe surface.
+ */
+export function proxy(request: NextRequest): NextResponse {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return NextResponse.next();
+  }
+
+  const { pathname } = request.nextUrl;
+  const hasMdSuffix = pathname.endsWith(".md");
+  const wantsMarkdown =
+    hasMdSuffix || prefersMarkdown(request.headers.get("accept") ?? "");
+
+  if (!wantsMarkdown) {
+    return NextResponse.next();
+  }
+
+  const rawPath = hasMdSuffix ? pathname.slice(0, -3) : pathname;
+
+  // Header negotiation: skip asset files (e.g. a `.png` with a broad Accept).
+  const lastSegment = rawPath.split("/").pop() ?? "";
+  if (!hasMdSuffix && lastSegment.includes(".")) {
+    return NextResponse.next();
+  }
+
+  const contentPath = normalizeMarkdownPath(rawPath);
+
+  // Embed the path in the rewrite target so the catch-all route reads it from
+  // the URL (`/api/markdown/blog/post`); root maps to `/api/markdown`.
+  const url = request.nextUrl.clone();
+  url.pathname =
+    contentPath === "/" ? "/api/markdown" : `/api/markdown${contentPath}`;
+  url.search = "";
+  return NextResponse.rewrite(url);
+}
+
+export const config = {
+  matcher: [
+    "/((?!api/|_next/|favicon.ico|robots.txt|sitemap.xml|llms\\.txt|llms-full\\.txt).*)",
+  ],
+};


### PR DESCRIPTION
## Problem / Intent

The starter rendered every page only as HTML through the React page builder — there was **no Markdown surface at all** (no `.md` route, no `Accept` negotiation, no serializer). The goal is to expose clean Markdown of any page for LLMs/agents, where page-builder blocks degrade into **semantic Markdown** (`## question` + answer) instead of leaking as raw component tags (`<FaqAccordion/>`). Markdown is produced by **serializing the structured Contentful data**, never by stripping rendered React — so a component can never appear as a tag. 

## Summary

- Any content page is now available as Markdown two ways: append **`.md`** to the URL (`/about.md`, `/blog/post.md`, `/index.md`) **or** send **`Accept: text/markdown`** / **`text/plain`** (q-value aware; `;q=0` returns HTML). Plain browser requests are untouched — proven: Chrome/Firefox/Safari/`*/*` all still get HTML, while agents (Claude Code sends `text/plain`) get Markdown.
- Page-builder blocks serialize through a registry keyed by `contentType.sys.id` (`hero`, `faqAccordion`, `featureCards`, `callToAction`); **unknown block types serialize to `""`** (fail-safe) so no component can leak. FAQs render as `### question` + answer, buttons as `[label](href)`, images as `![alt](url)`.
- Rich text is walked node-by-node into full-fidelity Markdown (headings, nested lists, blockquotes, `strong`/`em`/`code`, hyperlinks, embedded-asset images) with metacharacter escaping.
- The route is an optional catch-all, so the content path also works as a clean direct URL: `/api/markdown/blog/test-blog`.
- **Agent discoverability** on three layers: a per-page `<link rel="alternate" type="text/markdown">`, an enriched `llms.txt` (with a "For AI agents" negotiation guide + page/blog index), and a new `llms-full.txt` that serializes the entire site into one Markdown document for RAG.
- Correct HTTP semantics: `200` with `Vary: Accept`, `Content-Location`, `X-Robots-Tag: noindex, nofollow`; missing docs → `404`; upstream fetch failure → `503` (a transient CMS outage isn't a deleted page). Always serves published content.

## Core file changes

| File | Change |
| --- | --- |
| `apps/web/src/proxy.ts` | New Next 16 proxy: detects `.md`/`Accept` (q-aware, skips assets) and rewrites to the catch-all markdown route, embedding the path in the URL; excludes infra routes via `matcher`. |
| `apps/web/src/lib/markdown-path.ts` | New path/negotiation helpers: `normalizeMarkdownPath`, and `prefersMarkdown` treating `text/markdown` **and** `text/plain` as Markdown signals (browsers never send either). |
| `apps/web/src/lib/contentful/rich-text-to-markdown.ts` | New hand-written walk of the Contentful rich-text `Document` → Markdown, with `escapeMarkdown`/`formatUrl`/asset resolution; unknown/embedded nodes → `""`. |
| `apps/web/src/lib/contentful/page-builder-to-markdown.ts` | New block serializer registry keyed by `contentType.sys.id`, mirroring `BLOCK_COMPONENTS`; unknown types → `""`. Reuses `getButtonUrl`. |
| `apps/web/src/lib/markdown.ts` | New document assembly (`pageToMarkdown`/`blogPostToMarkdown`/`blogIndexToMarkdown`) + non-throwing fetchers so the route can distinguish `404` from `503`. |
| `apps/web/src/app/api/markdown/[[...path]]/route.ts` | New optional catch-all handler: maps path → home/page/blog/blog-index, sets negotiation/cache/robots headers, returns `200`/`404`/`503`. |
| `apps/web/src/app/llms.txt/route.ts` | New site index with a "For AI agents" guide and page/blog links to their `.md` twins; resilient to partial fetch failure. |
| `apps/web/src/app/llms-full.txt/route.ts` | New route serializing the whole site (all pages + blog posts) into one `---`-separated Markdown document. |
| `apps/web/src/lib/seo.ts` | Adds a per-page `<link rel="alternate" type="text/markdown">` via `alternates.types`, advertising each page's `.md` twin. |
| `apps/web/src/app/blog/[slug]/page.tsx` | Passes the full `/blog/<slug>` path to `getSEOMetadata` so both the canonical URL and the new Markdown alternate resolve (fixes a pre-existing bare-slug canonical). |
| `CLAUDE.md` | Documents the content-negotiation architecture + discoverability, and adds "add a serializer" to the page-builder-block checklist. |

## Verification

- [x] `pnpm --filter web check-types` — passes
- [x] `pnpm --filter web lint` — passes
- [x] `curl localhost:3000/about.md` and `curl -H "Accept: text/markdown" localhost:3000/about` → semantic Markdown, **no `<...>` component tags**
- [x] `curl -H "Accept: text/plain" localhost:3000/about` → Markdown (Claude Code); `curl -H "Accept: text/markdown;q=0" localhost:3000/about` → HTML
- [x] Browser Accept (`text/html,...,*/*;q=0.8`) → HTML; `curl localhost:3000/` default → HTML
- [x] `curl localhost:3000/api/markdown/blog/test-blog` → Markdown via the clean direct URL
- [x] `curl -sI localhost:3000/about.md` → `Vary: Accept`, `Content-Location`, `X-Robots-Tag: noindex, nofollow`
- [x] Missing page `.md` → `404`; `curl localhost:3000/llms.txt` and `curl localhost:3000/llms-full.txt` → agent index + full corpus
- [x] `curl -s localhost:3000/about | grep 'rel="alternate" type="text/markdown"'` → per-page twin advertised



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added generated Markdown endpoints for pages and blogs, plus full-site Markdown artifacts for AI agents.
  * Enabled automatic Markdown negotiation via `.md` URLs and compatible `Accept` headers.
  * Extended SEO alternates to advertise Markdown “twin” URLs and improved blog canonical/Markdown URL alignment.
* **Bug Fixes**
  * Ensured newly added PageBuilder block types are included in Markdown output instead of being omitted.
* **Documentation**
  * Documented Markdown content negotiation behavior, response status expectations, and Markdown serialization rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->